### PR TITLE
nispor: Use filter when seeking ifindex and MAC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ etherparse = "0.12.0"
 nix = "0.25.0"
 env_logger = "0.9.0"
 clap = { version = "3.2.17", features = ["derive"] }
-nispor = "1.2.7"
+nispor = "1.2.8"

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -239,7 +239,7 @@ impl DhcpUdpSocket {
         dst_ip: &Ipv4Addr,
         socket_timeout: u32,
     ) -> Result<Self, DhcpError> {
-        let socket = UdpSocket::bind(&format!(
+        let socket = UdpSocket::bind(format!(
             "{}:{}",
             src_ip,
             0 // Use random source port
@@ -252,7 +252,7 @@ impl DhcpUdpSocket {
         socket.set_write_timeout(Some(std::time::Duration::from_secs(
             socket_timeout.into(),
         )))?;
-        socket.connect(&format!("{}:{}", dst_ip, dhcproto::v4::SERVER_PORT))?;
+        socket.connect(format!("{}:{}", dst_ip, dhcproto::v4::SERVER_PORT))?;
 
         Ok(Self { socket })
     }


### PR DESCRIPTION
Use nispor filter to speed up the query of interface index and MAC address.