### PR TITLE
Add proxy mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "mzc"
 path = "src/mzc.rs"
 
 [dependencies]
-rand = "0.8.5"
+rand = { version = "0.8.5", default-features = false }
 libc = "0.2.132"
 byteorder = "1.4.3"
 dhcproto = "0.8.0"
@@ -20,5 +20,5 @@ log = "0.4.17"
 etherparse = "0.12.0"
 nix = "0.25.0"
 env_logger = "0.9.0"
-clap = { version = "3.2.17", features = ["derive"] }
+clap = { version = "3.2.17", features = ["cargo"] }
 nispor = "1.2.8"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ErrorKind {
     Timeout,

--- a/src/integ_tests/dhcpv4_proxy.rs
+++ b/src/integ_tests/dhcpv4_proxy.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{DhcpV4Client, DhcpV4Config, DhcpV4Lease};
+
+use super::env::{
+    DhcpServerEnv, TEST_NIC_CLI, TEST_PROXY_IP1, TEST_PROXY_MAC1,
+};
+
+const POLL_WAIT_TIME: isize = 5;
+
+#[test]
+fn test_dhcpv4_proxy() {
+    let _srv = DhcpServerEnv::start();
+
+    let config =
+        DhcpV4Config::new_proxy(TEST_NIC_CLI, TEST_PROXY_MAC1).unwrap();
+    let mut cli = DhcpV4Client::init(config, None).unwrap();
+
+    let lease = get_lease(&mut cli);
+    assert!(lease.is_some());
+    if let Some(lease) = lease {
+        assert_eq!(lease.yiaddr, TEST_PROXY_IP1);
+    }
+}
+
+fn get_lease(cli: &mut DhcpV4Client) -> Option<DhcpV4Lease> {
+    while let Ok(events) = cli.poll(POLL_WAIT_TIME) {
+        for event in events {
+            match cli.process(event) {
+                Ok(Some(lease)) => {
+                    return Some(lease);
+                }
+                Ok(None) => (),
+                Err(_) => {
+                    return None;
+                }
+            }
+        }
+    }
+    None
+}

--- a/src/integ_tests/env.rs
+++ b/src/integ_tests/env.rs
@@ -4,12 +4,15 @@ use std::process::{Child, Command};
 
 const TEST_DHCPD_NETNS: &str = "mozim_test";
 pub(crate) const TEST_NIC_CLI: &str = "dhcpcli";
+pub(crate) const TEST_PROXY_MAC1: &str = "00:11:22:33:44:55";
 const TEST_NIC_SRV: &str = "dhcpsrv";
 
 const TEST_DHCP_SRV_IP: &str = "192.0.2.1";
 
 pub(crate) const FOO1_STATIC_IP: std::net::Ipv4Addr =
     std::net::Ipv4Addr::new(192, 0, 2, 99);
+pub(crate) const TEST_PROXY_IP1: std::net::Ipv4Addr =
+    std::net::Ipv4Addr::new(192, 0, 2, 51);
 
 const DNSMASQ_OPTS: &str = r#"
 --log-dhcp
@@ -19,6 +22,7 @@ const DNSMASQ_OPTS: &str = r#"
 --dhcp-leasefile=/tmp/mozim_test_dhcpd_lease
 --no-hosts
 --dhcp-host=foo1,192.0.2.99
+--dhcp-host=00:11:22:33:44:55,192.0.2.51
 --dhcp-option=option:dns-server,8.8.8.8,1.1.1.1
 --dhcp-option=option:mtu,1492
 --dhcp-option=option:domain-name,example.com

--- a/src/integ_tests/mod.rs
+++ b/src/integ_tests/mod.rs
@@ -3,4 +3,7 @@
 #[cfg(test)]
 mod dhcpv4;
 
+#[cfg(test)]
+mod dhcpv4_proxy;
+
 mod env;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod event;
 mod lease;
 mod mac;
 mod msg;
+mod proiscuous;
 mod socket;
 mod time;
 

--- a/src/proiscuous.rs
+++ b/src/proiscuous.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{DhcpError, ErrorKind};
+
+pub(crate) fn enable_promiscuous_mode(
+    fd: libc::c_int,
+    iface_index: libc::c_int,
+) -> Result<(), DhcpError> {
+    let mreq = libc::packet_mreq {
+        mr_ifindex: iface_index,
+        mr_type: libc::PACKET_MR_PROMISC as libc::c_ushort,
+        mr_alen: 0,
+        mr_address: [0; 8],
+    };
+
+    unsafe {
+        let rc = libc::setsockopt(
+            fd,
+            libc::SOL_PACKET,
+            libc::PACKET_ADD_MEMBERSHIP,
+            (&mreq as *const libc::packet_mreq) as *const libc::c_void,
+            std::mem::size_of::<libc::packet_mreq>() as libc::socklen_t,
+        );
+        if rc != 0 {
+            return Err(DhcpError::new(
+                ErrorKind::Bug,
+                format!(
+                    "Failed to set socket to promiscuous mode with error: {}",
+                    rc
+                ),
+            ));
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Use case:
 * The host has eth1 with many MacVlan interfaces attached and those MacVlan
   interfaces are assigned to container namespace.

 * The host could run DHCP proxy on eth1 with the MAC address of these
   MacVlan interfaces to get lease from DHCP server and also refresh the
   lease afterwards.

 * Container will use this DHCP lease as static IPv4 without worry about
   DHCP process at all.

The mozim API:

```rust
let config = DhcpV4Config::new_proxy(out_going_interface, mac_to_proxy)?;
let mut cli = DhcpV4Client::init(config, None)?

loop {
    let events = cli.poll(POLL_WAIT_TIME)?;
    for event in events {
        if let Some(lease) = cli.process(event)? {
            // Send this lease info to container
        }
    }
}
```

CLI:

 * The old `mzc eth1` has changed to `mzc run eth1` for normal DHCP
   client process.

 * Introduced `mzc proxy eth1 <MAC_TO_PROXY>` to run DHCP proxy.

Limitation:
 * The renew stage is unicast to DHCP server. In proxy mode, it should
   be done in raw socket in order to send package on behalf of other
   interface. This requires ARP resolution. So this patch we skip renew
   stage and only do rebind(broadcast) during T1 and T2 timerange.

Integration test case included.