### PR TITLE
Add support of releasing DHCP lease

### DIFF
--- a/src/integ_tests/dhcpv4_proxy.rs
+++ b/src/integ_tests/dhcpv4_proxy.rs
@@ -20,6 +20,7 @@ fn test_dhcpv4_proxy() {
     assert!(lease.is_some());
     if let Some(lease) = lease {
         assert_eq!(lease.yiaddr, TEST_PROXY_IP1);
+        cli.release(&lease).unwrap();
     }
 }
 

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -6,6 +6,8 @@ use crate::DhcpError;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DhcpV4Lease {
+    // Required for sending DHCPRELEASE in proxy mode
+    pub(crate) srv_mac: [u8; 6],
     pub siaddr: Ipv4Addr,
     pub yiaddr: Ipv4Addr,
     pub t1: u32,
@@ -27,6 +29,7 @@ pub struct DhcpV4Lease {
 impl Default for DhcpV4Lease {
     fn default() -> Self {
         Self {
+            srv_mac: [u8::MAX; 6],
             siaddr: Ipv4Addr::new(0, 0, 0, 0),
             yiaddr: Ipv4Addr::new(0, 0, 0, 0),
             t1: 0,

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,6 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use log::error;
 
 use crate::{DhcpError, ErrorKind};
+
+pub(crate) const BROADCAST_MAC_ADDRESS: [u8; 6] = [u8::MAX; 6];
 
 pub(crate) fn mac_str_to_u8_array(mac: &str) -> Vec<u8> {
     let mut mac_bytes = Vec::new();

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -8,11 +8,12 @@ use std::os::unix::io::RawFd;
 use nix::errno::Errno;
 
 use crate::{
-    bpf::apply_dhcp_bpf, mac::mac_address_to_eth_mac_bytes,
-    proiscuous::enable_promiscuous_mode, DhcpError, DhcpV4Config, ErrorKind,
+    bpf::apply_dhcp_bpf,
+    mac::{mac_address_to_eth_mac_bytes, BROADCAST_MAC_ADDRESS},
+    proiscuous::enable_promiscuous_mode,
+    DhcpError, DhcpV4Config, ErrorKind,
 };
 
-const BROADCAST_MAC_ADDRESS: &str = "ff:ff:ff:ff:ff:ff";
 const PACKET_HOST: u8 = 0; // a packet addressed to the local host
 
 pub(crate) trait DhcpSocket {
@@ -82,9 +83,8 @@ impl DhcpSocket for DhcpRawSocket {
 
         let mut dst_addr: libc::sockaddr_ll = unsafe { std::mem::zeroed() };
         dst_addr.sll_halen = libc::ETH_ALEN as u8;
-        dst_addr.sll_addr[..libc::ETH_ALEN as usize].clone_from_slice(
-            &mac_address_to_eth_mac_bytes(BROADCAST_MAC_ADDRESS)?,
-        );
+        dst_addr.sll_addr[..libc::ETH_ALEN as usize]
+            .clone_from_slice(&BROADCAST_MAC_ADDRESS);
         dst_addr.sll_ifindex = self.config.iface_index as i32;
         let addr_buffer_size: libc::socklen_t =
             std::mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t;


### PR DESCRIPTION
Supporting DHCPRELEASE via `DhcpV4Client::release()`.


In normal mode, we use normal UDP socket to send unicast to server.
In proxy mode, we use ethernet RAW socket to send unicast to server
using the MAC address we got in the lease sent from DHCP server.

Integration test case included and manually confirmed dnsmasq log
shows:

    dnsmasq-dhcp: 1897809709 DHCPRELEASE(dhcpsrv) 192.0.2.51
    00:11:22:33:44:55