### PR TITLE
API changes: expose kind and msg of DhcpError, change `DhcpV4Config::new()`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -54,9 +54,10 @@ impl AsRawFd for DhcpV4Client {
 
 impl DhcpV4Client {
     pub fn init(
-        config: DhcpV4Config,
+        mut config: DhcpV4Config,
         lease: Option<DhcpV4Lease>,
     ) -> Result<Self, DhcpError> {
+        config.init()?;
         let mut event_pool = DhcpEventPool::new()?;
         event_pool.add_timer(config.timeout, DhcpV4Event::Timeout)?;
         let raw_socket = DhcpRawSocket::new(&config)?;
@@ -106,10 +107,7 @@ impl DhcpV4Client {
         self.udp_socket = None;
     }
 
-    pub fn poll(
-        &self,
-        wait_time: isize,
-    ) -> Result<Vec<DhcpV4Event>, DhcpError> {
+    pub fn poll(&self, wait_time: u32) -> Result<Vec<DhcpV4Event>, DhcpError> {
         self.event_pool.poll(wait_time)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,7 +117,7 @@ fn get_nispor_iface(iface_name: &str) -> Result<nispor::Iface, DhcpError> {
         Err(e) => {
             return Err(DhcpError::new(
                 ErrorKind::Bug,
-                format!("Faild to retrieve network state: {}", e),
+                format!("Faild to retrieve network state: {e}"),
             ))
         }
     };
@@ -126,7 +126,7 @@ fn get_nispor_iface(iface_name: &str) -> Result<nispor::Iface, DhcpError> {
     } else {
         Err(DhcpError::new(
             ErrorKind::InvalidArgument,
-            format!("Interface {} not found", iface_name),
+            format!("Interface {iface_name} not found"),
         ))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,27 +41,30 @@ impl Default for DhcpV4Config {
 }
 
 impl DhcpV4Config {
-    pub fn new(iface_name: &str) -> Result<Self, DhcpError> {
-        let np_iface = get_nispor_iface(iface_name)?;
-        Ok(Self {
-            iface_name: np_iface.name.to_string(),
-            iface_index: np_iface.index,
-            src_mac: np_iface.mac_address,
+    pub fn new(iface_name: &str) -> Self {
+        Self {
+            iface_name: iface_name.to_string(),
             ..Default::default()
-        })
+        }
     }
-    pub fn new_proxy(
-        out_iface_name: &str,
-        proxy_mac: &str,
-    ) -> Result<Self, DhcpError> {
-        let np_iface = get_nispor_iface(out_iface_name)?;
-        Ok(Self {
-            iface_name: np_iface.name.to_string(),
-            iface_index: np_iface.index,
+
+    // Check whether interface exists and resolve iface_index and MAC
+    pub(crate) fn init(&mut self) -> Result<(), DhcpError> {
+        let np_iface = get_nispor_iface(self.iface_name.as_str())?;
+        self.iface_index = np_iface.index;
+        if !self.is_proxy {
+            self.src_mac = np_iface.mac_address;
+        }
+        Ok(())
+    }
+
+    pub fn new_proxy(out_iface_name: &str, proxy_mac: &str) -> Self {
+        Self {
+            iface_name: out_iface_name.to_string(),
             src_mac: proxy_mac.to_string(),
             is_proxy: true,
             ..Default::default()
-        })
+        }
     }
 
     // Set timeout in seconds

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ impl DhcpError {
 
 impl std::fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -44,30 +44,30 @@ impl std::fmt::Display for DhcpError {
 
 impl From<std::io::Error> for DhcpError {
     fn from(e: std::io::Error) -> Self {
-        Self::new(ErrorKind::Bug, format!("IO error: {}", e))
+        Self::new(ErrorKind::Bug, format!("IO error: {e}"))
     }
 }
 
 impl From<std::ffi::NulError> for DhcpError {
     fn from(e: std::ffi::NulError) -> Self {
-        Self::new(ErrorKind::Bug, format!("CString error: {}", e))
+        Self::new(ErrorKind::Bug, format!("CString error: {e}"))
     }
 }
 
 impl From<dhcproto::v4::EncodeError> for DhcpError {
     fn from(e: dhcproto::v4::EncodeError) -> Self {
-        Self::new(ErrorKind::Bug, format!("DHCP protocol error: {}", e))
+        Self::new(ErrorKind::Bug, format!("DHCP protocol error: {e}"))
     }
 }
 
 impl From<etherparse::WriteError> for DhcpError {
     fn from(e: etherparse::WriteError) -> Self {
-        Self::new(ErrorKind::Bug, format!("etherparse protocol error: {}", e))
+        Self::new(ErrorKind::Bug, format!("etherparse protocol error: {e}"))
     }
 }
 
 impl From<std::net::AddrParseError> for DhcpError {
     fn from(e: std::net::AddrParseError) -> Self {
-        Self::new(ErrorKind::Bug, format!("IPv4 address parse error: {}", e))
+        Self::new(ErrorKind::Bug, format!("IPv4 address parse error: {e}"))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ErrorKind {
     Timeout,
     InvalidArgument,
@@ -19,6 +19,14 @@ pub struct DhcpError {
 impl DhcpError {
     pub fn new(kind: ErrorKind, msg: String) -> Self {
         Self { kind, msg }
+    }
+
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    pub fn msg(&self) -> &str {
+        self.msg.as_str()
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -43,7 +43,7 @@ impl TryFrom<u64> for DhcpV4Event {
             _ => {
                 let e = DhcpError::new(
                     ErrorKind::Bug,
-                    format!("Got unexpected event ID {}", v),
+                    format!("Got unexpected event ID {v}"),
                 );
                 log::error!("{}", e);
                 Err(e)
@@ -180,7 +180,7 @@ impl DhcpEpoll {
             fd: epoll_create().map_err(|e| {
                 let e = DhcpError::new(
                     ErrorKind::Bug,
-                    format!("Failed to epoll_create(): {}", e),
+                    format!("Failed to epoll_create(): {e}"),
                 );
                 log::error!("{}", e);
                 e
@@ -245,7 +245,7 @@ impl DhcpEpoll {
             .map_err(|e| {
                 let e = DhcpError::new(
                     ErrorKind::Bug,
-                    format!("Failed on epoll_wait(): {}", e),
+                    format!("Failed on epoll_wait(): {e}"),
                 );
                 log::error!("{}", e);
                 e

--- a/src/event.rs
+++ b/src/event.rs
@@ -147,9 +147,19 @@ impl DhcpEventPool {
 
     pub(crate) fn poll(
         &self,
-        wait_time: isize,
+        wait_time: u32,
     ) -> Result<Vec<DhcpV4Event>, DhcpError> {
-        self.epoll.poll(wait_time)
+        match isize::try_from(wait_time) {
+            Ok(i) => self.epoll.poll(i),
+            Err(_) => Err(DhcpError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Invalid timeout, should be in the range of \
+                            0 - {}",
+                    isize::MAX
+                ),
+            )),
+        }
     }
 }
 

--- a/src/integ_tests/dhcpv4.rs
+++ b/src/integ_tests/dhcpv4.rs
@@ -4,13 +4,13 @@ use crate::{DhcpV4Client, DhcpV4Config, DhcpV4Lease};
 
 use super::env::{DhcpServerEnv, FOO1_STATIC_IP, TEST_NIC_CLI};
 
-const POLL_WAIT_TIME: isize = 5;
+const POLL_WAIT_TIME: u32 = 5;
 
 #[test]
 fn test_dhcpv4_manual_client_id() {
     let _srv = DhcpServerEnv::start();
 
-    let mut config = DhcpV4Config::new(TEST_NIC_CLI).unwrap();
+    let mut config = DhcpV4Config::new(TEST_NIC_CLI);
     config.set_host_name("foo1");
     config.use_host_name_as_client_id();
     let mut cli = DhcpV4Client::init(config, None).unwrap();

--- a/src/integ_tests/dhcpv4_proxy.rs
+++ b/src/integ_tests/dhcpv4_proxy.rs
@@ -6,14 +6,13 @@ use super::env::{
     DhcpServerEnv, TEST_NIC_CLI, TEST_PROXY_IP1, TEST_PROXY_MAC1,
 };
 
-const POLL_WAIT_TIME: isize = 5;
+const POLL_WAIT_TIME: u32 = 5;
 
 #[test]
 fn test_dhcpv4_proxy() {
     let _srv = DhcpServerEnv::start();
 
-    let config =
-        DhcpV4Config::new_proxy(TEST_NIC_CLI, TEST_PROXY_MAC1).unwrap();
+    let config = DhcpV4Config::new_proxy(TEST_NIC_CLI, TEST_PROXY_MAC1);
     let mut cli = DhcpV4Client::init(config, None).unwrap();
 
     let lease = get_lease(&mut cli);

--- a/src/integ_tests/env.rs
+++ b/src/integ_tests/env.rs
@@ -58,35 +58,31 @@ impl Drop for DhcpServerEnv {
 }
 
 fn create_test_net_namespace() {
-    run_cmd(&format!("ip netns add {}", TEST_DHCPD_NETNS));
+    run_cmd(&format!("ip netns add {TEST_DHCPD_NETNS}"));
 }
 
 fn remove_test_net_namespace() {
-    run_cmd_ignore_failure(&format!("ip netns del {}", TEST_DHCPD_NETNS));
+    run_cmd_ignore_failure(&format!("ip netns del {TEST_DHCPD_NETNS}"));
 }
 
 fn create_test_veth_nics() {
     run_cmd(&format!(
-        "ip link add {} type veth peer name {}",
-        TEST_NIC_CLI, TEST_NIC_SRV
+        "ip link add {TEST_NIC_CLI} type veth peer name {TEST_NIC_SRV}"
     ));
-    run_cmd(&format!("ip link set {} up", TEST_NIC_CLI));
+    run_cmd(&format!("ip link set {TEST_NIC_CLI} up"));
     run_cmd(&format!(
-        "ip link set {} netns {}",
-        TEST_NIC_SRV, TEST_DHCPD_NETNS
+        "ip link set {TEST_NIC_SRV} netns {TEST_DHCPD_NETNS}"
     ));
     run_cmd(&format!(
-        "ip netns exec {} ip link set {} up",
-        TEST_DHCPD_NETNS, TEST_NIC_SRV,
+        "ip netns exec {TEST_DHCPD_NETNS} ip link set {TEST_NIC_SRV} up",
     ));
     run_cmd(&format!(
-        "ip netns exec {} ip addr add {}/24 dev {}",
-        TEST_DHCPD_NETNS, TEST_DHCP_SRV_IP, TEST_NIC_SRV,
+        "ip netns exec {TEST_DHCPD_NETNS} ip addr add {TEST_DHCP_SRV_IP}/24 dev {TEST_NIC_SRV}",
     ));
 }
 
 fn remove_test_veth_nics() {
-    run_cmd_ignore_failure(&format!("ip link del {}", TEST_NIC_CLI));
+    run_cmd_ignore_failure(&format!("ip link del {TEST_NIC_CLI}"));
 }
 
 fn start_dhcp_server() -> Child {
@@ -102,7 +98,7 @@ fn start_dhcp_server() -> Child {
         .expect("Failed to start DHCP server");
     std::thread::sleep(std::time::Duration::from_secs(1));
     if let Ok(Some(ret)) = child.try_wait() {
-        panic!("Failed to start DHCP server {:?}", ret);
+        panic!("Failed to start DHCP server {ret:?}");
     }
     child
 }
@@ -117,7 +113,7 @@ fn run_cmd(cmd: &str) -> String {
         Command::new(cmds[0])
             .args(&cmds[1..])
             .output()
-            .unwrap_or_else(|_| panic!("failed to execute command {}", cmd))
+            .unwrap_or_else(|_| panic!("failed to execute command {cmd}"))
             .stdout,
     )
     .expect("Failed to convert file command output to String")
@@ -129,7 +125,7 @@ fn run_cmd_ignore_failure(cmd: &str) -> String {
     match Command::new(cmds[0]).args(&cmds[1..]).output() {
         Ok(o) => String::from_utf8(o.stdout).unwrap_or_default(),
         Err(e) => {
-            eprintln!("Failed to execute command {}: {}", cmd, e);
+            eprintln!("Failed to execute command {cmd}: {e}");
             "".to_string()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,6 @@ mod integ_tests;
 pub use crate::client::DhcpV4Client;
 pub use crate::config::DhcpV4Config;
 pub use crate::error::{DhcpError, ErrorKind};
+pub use crate::event::DhcpV4Event;
 pub use crate::lease::DhcpV4Lease;
 pub use crate::msg::{DhcpV4Message, DhcpV4MessageType};

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -164,7 +164,7 @@ impl DhcpV4Message {
             } else {
                 return Err(DhcpError::new(
                     ErrorKind::Bug,
-                    format!("Got no lease for RELEASE message: {:?}", self),
+                    format!("Got no lease for RELEASE message: {self:?}"),
                 ));
             }
         } else {
@@ -200,8 +200,7 @@ impl DhcpV4Message {
                     ErrorKind::InvalidDhcpServerReply,
                     format!(
                         "Failed to parse DHCP message from payload of pkg \
-                        {:?}: {}",
-                        payload, decode_error
+                        {payload:?}: {decode_error}"
                     ),
                 );
                 log::error!("{}", e);
@@ -276,8 +275,7 @@ impl DhcpV4Message {
                 let e = DhcpError::new(
                     ErrorKind::InvalidDhcpServerReply,
                     format!(
-                        "Failed to parse ethernet package to Dhcpv4Offer: {}",
-                        error
+                        "Failed to parse ethernet package to Dhcpv4Offer: {error}"
                     ),
                 );
                 log::error!("{}", e);

--- a/src/mzc.rs
+++ b/src/mzc.rs
@@ -284,18 +284,18 @@ fn proxy(iface_name: &str, mac: &str, timeout: u32) {
                 for event in events {
                     match cli.process(event) {
                         Ok(Some(lease)) => {
-                            println!("{:?}", lease);
+                            println!("{lease:?}");
                         }
                         Ok(None) => (),
                         Err(e) => {
-                            eprintln!("Error {:?}", e);
+                            eprintln!("Error {e:?}");
                             return;
                         }
                     }
                 }
             }
             Err(e) => {
-                eprintln!("Error {:?}", e);
+                eprintln!("Error {e:?}");
                 break;
             }
         }

--- a/src/mzc.rs
+++ b/src/mzc.rs
@@ -8,7 +8,7 @@ use nispor::{
 };
 
 const DEFAULT_METRIC: u32 = 500;
-const POLL_WAIT_TIME: isize = 5;
+const POLL_WAIT_TIME: u32 = 5;
 const APP_NAME: &str = "mzc";
 
 const SUBCOMMAND_RUN: &str = "run";
@@ -124,7 +124,7 @@ fn main() {
 fn run(iface_name: &str, timeout: u32) {
     purge_dhcp_ip_route(iface_name);
 
-    let mut config = DhcpV4Config::new(iface_name).unwrap();
+    let mut config = DhcpV4Config::new(iface_name);
     config.set_host_name("Gris-Laptop");
     config.use_host_name_as_client_id();
     config.set_timeout(timeout);
@@ -274,7 +274,7 @@ fn gen_rt_conf(
 }
 
 fn proxy(iface_name: &str, mac: &str, timeout: u32) {
-    let mut config = DhcpV4Config::new_proxy(iface_name, mac).unwrap();
+    let mut config = DhcpV4Config::new_proxy(iface_name, mac);
     config.set_timeout(timeout);
     let mut cli = DhcpV4Client::init(config, None).unwrap();
 

--- a/src/proiscuous.rs
+++ b/src/proiscuous.rs
@@ -25,8 +25,7 @@ pub(crate) fn enable_promiscuous_mode(
             return Err(DhcpError::new(
                 ErrorKind::Bug,
                 format!(
-                    "Failed to set socket to promiscuous mode with error: {}",
-                    rc
+                    "Failed to set socket to promiscuous mode with error: {rc}"
                 ),
             ));
         }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -222,7 +222,7 @@ fn bind_raw_socket(
                 libc::close(fd);
                 Err(DhcpError::new(
                     ErrorKind::Bug,
-                    format!("Failed to bind socket: {}", rc),
+                    format!("Failed to bind socket: {rc}"),
                 ))
             }
         }
@@ -302,8 +302,7 @@ fn set_socket_timeout(fd: libc::c_int, timeout: u32) -> Result<(), DhcpError> {
                 ErrorKind::Bug,
                 format!(
                     "Failed to set the send timeout SO_SNDTIMEO to \
-                    socket {}: {}",
-                    fd, rc
+                    socket {fd}: {rc}"
                 ),
             ));
         }
@@ -319,8 +318,7 @@ fn set_socket_timeout(fd: libc::c_int, timeout: u32) -> Result<(), DhcpError> {
                 ErrorKind::Bug,
                 format!(
                     "Failed to set the recv timeout SO_RCVTIMEO to \
-                    socket {}: {}",
-                    fd, rc
+                    socket {fd}: {rc}"
                 ),
             );
             log::error!("{}", e);

--- a/src/time.rs
+++ b/src/time.rs
@@ -26,7 +26,7 @@ impl DhcpTimerFd {
             TimerFd::new(CLOCK_BOOTTIME, TimerFlags::empty()).map_err(|e| {
                 let e = DhcpError::new(
                     ErrorKind::Bug,
-                    format!("Failed to create timerfd {}", e),
+                    format!("Failed to create timerfd {e}"),
                 );
                 log::error!("{}", e);
                 e
@@ -38,7 +38,7 @@ impl DhcpTimerFd {
         .map_err(|e| {
             let e = DhcpError::new(
                 ErrorKind::Bug,
-                format!("Failed to set timerfd {}", e),
+                format!("Failed to set timerfd {e}"),
             );
             log::error!("{}", e);
             e


### PR DESCRIPTION
* Expose `DhcpError::kind()` and `DhcpError::msg()`.
 * Change the `DhcpV4Config::new()` to return `DhcpV4Config` which does
   not try to check interface in kernel. The `DhcpV4Config::init()`
   invoked by `DhcpV4Client::init()` will do the check and fill up the
   interface index and MAC address.