### PR TITLE
Fix (54) DHCP Server Identifier

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -124,9 +124,15 @@ impl DhcpV4Message {
                 if self.renew_or_rebind {
                     dhcp_msg.set_ciaddr(lease.yiaddr);
                 } else {
-                    dhcp_msg
-                        .opts_mut()
-                        .insert(v4::DhcpOption::ServerIdentifier(lease.siaddr));
+                    if lease.srv_id != Ipv4Addr::new(0, 0, 0, 0) {
+                        dhcp_msg.opts_mut().insert(
+                            v4::DhcpOption::ServerIdentifier(lease.srv_id),
+                        );
+                    } else {
+                        dhcp_msg.opts_mut().insert(
+                            v4::DhcpOption::ServerIdentifier(lease.siaddr),
+                        );
+                    }
                     dhcp_msg.opts_mut().insert(
                         v4::DhcpOption::RequestedIpAddress(lease.yiaddr),
                     );
@@ -158,9 +164,15 @@ impl DhcpV4Message {
                 dhcp_msg.opts_mut().insert(v4::DhcpOption::MessageType(
                     v4::MessageType::Release,
                 ));
-                dhcp_msg
-                    .opts_mut()
-                    .insert(v4::DhcpOption::ServerIdentifier(lease.siaddr));
+                if lease.srv_id != Ipv4Addr::new(0, 0, 0, 0) {
+                    dhcp_msg
+                        .opts_mut()
+                        .insert(v4::DhcpOption::ServerIdentifier(lease.srv_id));
+                } else {
+                    dhcp_msg
+                        .opts_mut()
+                        .insert(v4::DhcpOption::ServerIdentifier(lease.siaddr));
+                }
             } else {
                 return Err(DhcpError::new(
                     ErrorKind::Bug,


### PR DESCRIPTION
Problem:

Some DHCP server set server IP as 0.0.0.0 and store correct IP address
in the DHCP option `Server Identifier(54)`, they also expecting DHCP
client use that field also on the DHCP request and release, otherwise that
DHCP server will ignore DHCP request or release package.

Root cause:

mozim is using `siaddr` instead of DHCP option
`Server Identifier(54)` for DHCP request and release.

Fix:

When lease contains valid(not all zero) `Server Identifier(54)`, we use
it, use `siaddr` otherwise.

Test:

It require special DHCP server which I have no idea what. Manually
tested.