### PR TITLE
New release 0.2.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
 # Changelog
+## [0.2.4] - 2024-07-10
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Apply BPF filter right after raw socket been created. (e34bc25)
+ - Ignore invalid DHCP message during discovery and request stage. (fed292c)
+
 ## [0.2.3] - 2024-02-19
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozim"
-version = "0.2.3"
+version = "0.2.4"
 description = "DHCP Client Library"
 license = "Apache-2.0"
 homepage = "https://github.com/nispor/mozim"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Apply BPF filter right after raw socket been created. (e34bc25)
 - Ignore invalid DHCP message during discovery and request stage. (fed292c)