### PR TITLE
Fix various issues with hostname and client id

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -102,10 +102,10 @@ impl DhcpV4Config {
         if !self.host_name.is_empty() {
             // RFC 2132: 9.14. Client-identifier
             // Type 0 is used when not using hardware address
-            self.client_id = vec![0];
             // The RFC never mentioned the NULL terminator for string.
             // TODO: Need to check with dnsmasq implementation
-            self.client_id.extend_from_slice(self.host_name.as_bytes());
+            let host_name = self.host_name.clone();
+            self.set_client_id(0, host_name.as_bytes());
         }
         self
     }
@@ -116,10 +116,7 @@ impl DhcpV4Config {
         client_id: &[u8],
     ) -> &mut Self {
         // RFC 2132: 9.14. Client-identifier
-        // Type 0 is used when not using hardware address
         self.client_id = vec![client_id_type];
-        // The RFC never mentioned the NULL terminator for string.
-        // TODO: Need to check with dnsmasq implementation
         self.client_id.extend_from_slice(client_id);
         self
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,7 +110,11 @@ impl DhcpV4Config {
         self
     }
 
-    pub fn set_client_id(&mut self, client_id_type: u8, client_id: &[u8]) -> &mut Self {
+    pub fn set_client_id(
+        &mut self,
+        client_id_type: u8,
+        client_id: &[u8],
+    ) -> &mut Self {
         // RFC 2132: 9.14. Client-identifier
         // Type 0 is used when not using hardware address
         self.client_id = vec![client_id_type];

--- a/src/integ_tests/dhcpv4.rs
+++ b/src/integ_tests/dhcpv4.rs
@@ -2,33 +2,42 @@
 
 use crate::{DhcpV4Client, DhcpV4Config, DhcpV4Lease};
 
-use super::env::{DhcpServerEnv, FOO1_CLIENT_ID, FOO1_HOSTNAME, FOO1_STATIC_IP, TEST_NIC_CLI};
+use super::env::{
+    with_dhcp_env, FOO1_CLIENT_ID, FOO1_HOSTNAME, FOO1_STATIC_IP, TEST_NIC_CLI,
+};
 
 const POLL_WAIT_TIME: u32 = 5;
 
 #[test]
 fn test_dhcpv4_manual_client_id() {
-    let _srv = DhcpServerEnv::start();
+    with_dhcp_env(|| {
+        let mut config = DhcpV4Config::new(TEST_NIC_CLI);
+        config.set_client_id(0, FOO1_CLIENT_ID.as_bytes());
 
-    let mut config = DhcpV4Config::new(TEST_NIC_CLI);
-    config.set_client_id(0, FOO1_CLIENT_ID.as_bytes());
-    
-    let mut client_id = vec![0];
-    client_id.extend_from_slice(FOO1_CLIENT_ID.as_bytes());
-    assert_eq!(config.client_id, client_id);
+        let mut client_id = vec![0];
+        client_id.extend_from_slice(FOO1_CLIENT_ID.as_bytes());
+        assert_eq!(config.client_id, client_id);
 
-    let mut cli = DhcpV4Client::init(config, None).unwrap();
+        let mut cli = DhcpV4Client::init(config, None).unwrap();
 
-    let lease = get_lease(&mut cli);
-    assert!(lease.is_some());
-    if let Some(lease) = lease {
-        // Even though we didn't send it in the DHCP request, dnsmasq should return
-        // the hostname since it was set in the --dhcp-host option
-        assert_eq!(lease.host_name.as_ref(), Some(&FOO1_HOSTNAME.to_string()));
-        // If the client id was set correctly to FOO1_CLIENT_ID then the
-        // server should return FOO1_STATIC_IP.
-        assert_eq!(lease.yiaddr, FOO1_STATIC_IP,);
-    }
+        let lease = get_lease(&mut cli);
+
+        println!("HAHA {:?}", lease);
+
+        assert!(lease.is_some());
+        if let Some(lease) = lease {
+            // Even though we didn't send it in the DHCP request, dnsmasq should
+            // return the hostname since it was set in the --dhcp-host
+            // option
+            assert_eq!(
+                lease.host_name.as_ref(),
+                Some(&FOO1_HOSTNAME.to_string())
+            );
+            // If the client id was set correctly to FOO1_CLIENT_ID then the
+            // server should return FOO1_STATIC_IP.
+            assert_eq!(lease.yiaddr, FOO1_STATIC_IP,);
+        }
+    })
 }
 
 fn get_lease(cli: &mut DhcpV4Client) -> Option<DhcpV4Lease> {

--- a/src/integ_tests/dhcpv4_async.rs
+++ b/src/integ_tests/dhcpv4_async.rs
@@ -4,15 +4,31 @@ use futures::StreamExt;
 
 use crate::{DhcpV4ClientAsync, DhcpV4Config, DhcpV4Lease};
 
-use super::env::{DhcpServerEnv, FOO1_STATIC_IP, TEST_NIC_CLI};
+use super::env::{DhcpServerEnv, FOO1_HOSTNAME, FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID, TEST_NIC_CLI};
+
+const FOO2_HOSTNAME: &str = "foo2";
 
 #[test]
 fn test_dhcpv4_async() {
     let _srv = DhcpServerEnv::start();
 
     let mut config = DhcpV4Config::new(TEST_NIC_CLI);
-    config.set_host_name("foo1");
+    // Since hostname hasn't been set yet, client_id should be empty.
     config.use_host_name_as_client_id();
+    assert_eq!(config.client_id.len(), 0);
+
+    config.set_host_name(FOO1_HOSTNAME);
+    config.use_host_name_as_client_id();
+    // Now client id should be set to 0 + hostname.
+    let mut client_id = vec![0];
+    client_id.extend_from_slice(FOO1_HOSTNAME.as_bytes());
+    assert_eq!(config.client_id, client_id);
+    // config.use_host_name_as_client_id() copies the current hostname to client_id
+    // at the time it was called.  We should now change the hostname to
+    // something dnsmasq doesn't know about so we're sure we get the correct
+    // ip address based on the client id (original hostname) and not the
+    // hostname we're now sending in option 12.
+    config.set_host_name(FOO2_HOSTNAME);
 
     let mut cli = DhcpV4ClientAsync::init(config, None).unwrap();
 
@@ -24,8 +40,13 @@ fn test_dhcpv4_async() {
     let lease = rt.block_on(get_lease(&mut cli));
     assert!(lease.is_some());
     if let Some(lease) = lease {
-        assert_eq!(lease.host_name.as_ref(), Some(&"foo1".to_string()));
-        assert_eq!(lease.yiaddr, FOO1_STATIC_IP,);
+        // We should get FOO2_HOSTNAME as the hostname since that's what we
+        // sent in option 12 in the DHCP request.
+        assert_eq!(lease.host_name.as_ref(), Some(&FOO2_HOSTNAME.to_string()));
+        // If the client id was set correctly to FOO1_HOSTNAME via the
+        // call to use_host_name_as_client_id(), then the server should
+        // return FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID.
+        assert_eq!(lease.yiaddr, FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID,);
     }
 }
 

--- a/src/integ_tests/dhcpv4_async.rs
+++ b/src/integ_tests/dhcpv4_async.rs
@@ -4,50 +4,56 @@ use futures::StreamExt;
 
 use crate::{DhcpV4ClientAsync, DhcpV4Config, DhcpV4Lease};
 
-use super::env::{DhcpServerEnv, FOO1_HOSTNAME, FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID, TEST_NIC_CLI};
+use super::env::{
+    with_dhcp_env, FOO1_HOSTNAME, FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID,
+    TEST_NIC_CLI,
+};
 
 const FOO2_HOSTNAME: &str = "foo2";
 
 #[test]
 fn test_dhcpv4_async() {
-    let _srv = DhcpServerEnv::start();
+    with_dhcp_env(|| {
+        let mut config = DhcpV4Config::new(TEST_NIC_CLI);
+        // Since hostname hasn't been set yet, client_id should be empty.
+        config.use_host_name_as_client_id();
+        assert_eq!(config.client_id.len(), 0);
 
-    let mut config = DhcpV4Config::new(TEST_NIC_CLI);
-    // Since hostname hasn't been set yet, client_id should be empty.
-    config.use_host_name_as_client_id();
-    assert_eq!(config.client_id.len(), 0);
+        config.set_host_name(FOO1_HOSTNAME);
+        config.use_host_name_as_client_id();
+        // Now client id should be set to 0 + hostname.
+        let mut client_id = vec![0];
+        client_id.extend_from_slice(FOO1_HOSTNAME.as_bytes());
+        assert_eq!(config.client_id, client_id);
+        // config.use_host_name_as_client_id() copies the current hostname to
+        // client_id at the time it was called.  We should now change the
+        // hostname to something dnsmasq doesn't know about so we're sure we get
+        // the correct ip address based on the client id (original hostname) and
+        // not the hostname we're now sending in option 12.
+        config.set_host_name(FOO2_HOSTNAME);
 
-    config.set_host_name(FOO1_HOSTNAME);
-    config.use_host_name_as_client_id();
-    // Now client id should be set to 0 + hostname.
-    let mut client_id = vec![0];
-    client_id.extend_from_slice(FOO1_HOSTNAME.as_bytes());
-    assert_eq!(config.client_id, client_id);
-    // config.use_host_name_as_client_id() copies the current hostname to client_id
-    // at the time it was called.  We should now change the hostname to
-    // something dnsmasq doesn't know about so we're sure we get the correct
-    // ip address based on the client id (original hostname) and not the
-    // hostname we're now sending in option 12.
-    config.set_host_name(FOO2_HOSTNAME);
+        let mut cli = DhcpV4ClientAsync::init(config, None).unwrap();
 
-    let mut cli = DhcpV4ClientAsync::init(config, None).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .build()
+            .unwrap();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_io()
-        .build()
-        .unwrap();
-
-    let lease = rt.block_on(get_lease(&mut cli));
-    assert!(lease.is_some());
-    if let Some(lease) = lease {
-        // We should get FOO2_HOSTNAME as the hostname since that's what we
-        // sent in option 12 in the DHCP request.
-        assert_eq!(lease.host_name.as_ref(), Some(&FOO2_HOSTNAME.to_string()));
-        // If the client id was set correctly to FOO1_HOSTNAME via the
-        // call to use_host_name_as_client_id(), then the server should
-        // return FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID.
-        assert_eq!(lease.yiaddr, FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID,);
-    }
+        let lease = rt.block_on(get_lease(&mut cli));
+        assert!(lease.is_some());
+        if let Some(lease) = lease {
+            // We should get FOO2_HOSTNAME as the hostname since that's what we
+            // sent in option 12 in the DHCP request.
+            assert_eq!(
+                lease.host_name.as_ref(),
+                Some(&FOO2_HOSTNAME.to_string())
+            );
+            // If the client id was set correctly to FOO1_HOSTNAME via the
+            // call to use_host_name_as_client_id(), then the server should
+            // return FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID.
+            assert_eq!(lease.yiaddr, FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID,);
+        }
+    })
 }
 
 async fn get_lease(cli: &mut DhcpV4ClientAsync) -> Option<DhcpV4Lease> {

--- a/src/integ_tests/dhcpv4_proxy.rs
+++ b/src/integ_tests/dhcpv4_proxy.rs
@@ -3,24 +3,24 @@
 use crate::{DhcpV4Client, DhcpV4Config, DhcpV4Lease};
 
 use super::env::{
-    DhcpServerEnv, TEST_NIC_CLI, TEST_PROXY_IP1, TEST_PROXY_MAC1,
+    with_dhcp_env, TEST_NIC_CLI, TEST_PROXY_IP1, TEST_PROXY_MAC1,
 };
 
 const POLL_WAIT_TIME: u32 = 5;
 
 #[test]
 fn test_dhcpv4_proxy() {
-    let _srv = DhcpServerEnv::start();
+    with_dhcp_env(|| {
+        let config = DhcpV4Config::new_proxy(TEST_NIC_CLI, TEST_PROXY_MAC1);
+        let mut cli = DhcpV4Client::init(config, None).unwrap();
 
-    let config = DhcpV4Config::new_proxy(TEST_NIC_CLI, TEST_PROXY_MAC1);
-    let mut cli = DhcpV4Client::init(config, None).unwrap();
-
-    let lease = get_lease(&mut cli);
-    assert!(lease.is_some());
-    if let Some(lease) = lease {
-        assert_eq!(lease.yiaddr, TEST_PROXY_IP1);
-        cli.release(&lease).unwrap();
-    }
+        let lease = get_lease(&mut cli);
+        assert!(lease.is_some());
+        if let Some(lease) = lease {
+            assert_eq!(lease.yiaddr, TEST_PROXY_IP1);
+            cli.release(&lease).unwrap();
+        }
+    })
 }
 
 fn get_lease(cli: &mut DhcpV4Client) -> Option<DhcpV4Lease> {

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -191,7 +191,7 @@ impl DhcpV4Message {
         dhcp_msg.opts_mut().insert(v4::DhcpOption::ClientIdentifier(
             self.config.client_id.clone(),
         ));
-        if self.config.use_host_name_as_client_id {
+        if !self.config.host_name.is_empty() {
             dhcp_msg.opts_mut().insert(v4::DhcpOption::Hostname(
                 self.config.host_name.clone(),
             ));


### PR DESCRIPTION
* For some reason, the determination of whether to send the Hostname option on
  Discover and Request mesages was based on whether
  config.use_host_name_as_client_id was set.  However, using the hostname as
  the client id has nothing to do with whether the Hostname option should be
  sent or not.  We now always send the Hostname option if it was set.

* Added a check to use_host_name_as_client_id() to make sure we don't set
  client_id to just `[0]` if hostname hasn't been set.

* Added a new `set_client_id(client_id_type: u8, client_id: &[u8])` function
  to explicitly set the client id.

* Updated integ_tests/env.rs to parameterize the creation of the dnsmasq
  options.

* Updated test_dhcpv4_manual_client_id to check that set_client_id() set
  config.client_id correctly.

* Updated test_dhcpv4_async to check that use_host_name_as_client_id() doesn't
  set config.client_id if set_host_name() hasn't been called yet and to check
  that set config.client_id correctly when set_host_name() and
  use_host_name_as_client_id() are called in the proper order.

Resolves: #37
Resolves: #38

Signed-off-by: George Joseph <g.devel@wxy78.net>
