### PR TITLE
epoll: do not close twice

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -83,11 +83,6 @@ pub(crate) struct DhcpEventPool {
 impl Drop for DhcpEventPool {
     fn drop(&mut self) {
         self.remove_all_event();
-        if self.epoll.as_raw_fd() >= 0 {
-            unsafe {
-                libc::close(self.epoll.as_raw_fd() as libc::c_int);
-            }
-        }
     }
 }
 


### PR DESCRIPTION
The returned nix Epoll event is returning an OwnedFd that will automatically get closed on drop() so it does not close the Fd here.

In fact closing the fd makes rust abort as of v1.80[1], this can be easily seen by running the DHCP tests.

[1] https://github.com/rust-lang/rust/commit/38ded129236f112a7421f311aeb8ca750b661443