### PR TITLE
New release 0.2.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.2.5] - 2024-07-10
+### Breaking changes
+ - N/A
+
+### New features
+ - Support arbitrary client ID via `DhcpV4Config.set_client_id()`. (5f9a606)
+
+### Bug fixes
+ - epoll: do not close twice. (bff0a0c)
+
 ## [0.2.4] - 2024-07-10
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozim"
-version = "0.2.4"
+version = "0.2.5"
 description = "DHCP Client Library"
 license = "Apache-2.0"
 homepage = "https://github.com/nispor/mozim"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - Support arbitrary client ID via `DhcpV4Config.set_client_id()`. (5f9a606)

=== Bug fixes
 - epoll: do not close twice. (bff0a0c)