### PR TITLE
Add lease release support in ASYNC API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ TODO:
 # The `eth1.ep` is DHCP server interface running dnsmasq in `mozim` network
 # namespace.
 sudo ./utils/test_env_mozim &
-cargo run --example mozim_dhcpv4_sync
+cargo run --example mozim_dhcpv4_async
 cargo run --example mozim_dhcpv6_sync
 ```

--- a/examples/mozim_dhcpv4_async.rs
+++ b/examples/mozim_dhcpv4_async.rs
@@ -15,13 +15,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     config.set_timeout(60);
     let mut cli = DhcpV4ClientAsync::init(config, None).unwrap();
 
-    while let Some(Ok(lease)) = cli.next().await {
-        // You need to code to apply the IP address in lease to this NIC, so
-        // follow up renew can work.
-        println!("Got lease {lease:?}");
+    loop {
+        if let Some(Ok(lease)) = cli.next().await {
+            // You need to code to apply the IP address in lease to this NIC, so
+            // follow up renew can work.
+            println!("Got lease {lease:?}");
+            cli.release(&lease)?;
+            return Ok(());
+        }
     }
-
-    Ok(())
 }
 
 fn enable_log() {

--- a/examples/mozim_dhcpv6_sync.rs
+++ b/examples/mozim_dhcpv6_sync.rs
@@ -16,6 +16,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         for event in cli.poll(POLL_WAIT_TIME)? {
             if let Some(lease) = cli.process(event)? {
                 println!("Got DHCPv6 lease {:?}", lease);
+                cli.release(&lease)?;
+                return Ok(());
             }
         }
     }

--- a/src/client_async.rs
+++ b/src/client_async.rs
@@ -29,6 +29,13 @@ pub struct DhcpV4ClientAsync {
     share_state: Arc<Mutex<ShareState>>,
 }
 
+impl DhcpV4ClientAsync {
+    /// Release the lease acquired from DHCPv4 server.
+    pub fn release(&mut self, lease: &DhcpV4Lease) -> Result<(), DhcpError> {
+        self.client.release(lease)
+    }
+}
+
 impl Stream for DhcpV4ClientAsync {
     type Item = Result<DhcpV4Lease, DhcpError>;
 
@@ -239,5 +246,12 @@ impl std::ops::Drop for DhcpV6ClientAsync {
             // Signal `poll_thread()` to quit
             s.waker = None;
         }
+    }
+}
+
+impl DhcpV6ClientAsync {
+    /// Release the lease acquired from DHCPv6 server.
+    pub fn release(&mut self, lease: &DhcpV6Lease) -> Result<(), DhcpError> {
+        self.client.release(lease)
     }
 }

--- a/src/dhcpv6/lease.rs
+++ b/src/dhcpv6/lease.rs
@@ -28,6 +28,7 @@ pub struct DhcpV6Lease {
     pub cli_duid: Vec<u8>,
     pub srv_duid: Vec<u8>,
     pub dhcp_opts: Vec<dhcproto::v6::DhcpOption>,
+    pub srv_ip: Ipv6Addr,
 }
 
 impl Default for DhcpV6Lease {
@@ -45,6 +46,7 @@ impl Default for DhcpV6Lease {
             cli_duid: Vec::new(),
             srv_duid: Vec::new(),
             dhcp_opts: Vec::new(),
+            srv_ip: Ipv6Addr::UNSPECIFIED,
         }
     }
 }
@@ -78,6 +80,9 @@ impl std::convert::TryFrom<&v6::Message> for DhcpV6Lease {
                     ret.t1 = v.t1;
                     ret.t2 = v.t2;
                     parse_dhcp_opt_iaadr(&v.opts, &mut ret);
+                }
+                DhcpOption::ServerUnicast(srv_ip) => {
+                    ret.srv_ip = *srv_ip;
                 }
                 DhcpOption::StatusCode(v) => {
                     if v.status != v6::Status::Success {

--- a/src/dhcpv6/msg.rs
+++ b/src/dhcpv6/msg.rs
@@ -29,6 +29,8 @@ impl DhcpV6MessageType {
     pub(crate) const REPLY: Self = DhcpV6MessageType(v6::MessageType::Reply);
     pub(crate) const RENEW: Self = DhcpV6MessageType(v6::MessageType::Renew);
     pub(crate) const REBIND: Self = DhcpV6MessageType(v6::MessageType::Rebind);
+    pub(crate) const RELEASE: Self =
+        DhcpV6MessageType(v6::MessageType::Release);
 }
 
 impl Default for DhcpV6MessageType {
@@ -170,7 +172,9 @@ impl DhcpV6Message {
 
         match self.msg_type {
             DhcpV6MessageType::SOLICIT | DhcpV6MessageType::REBIND => (),
-            DhcpV6MessageType::REQUEST | DhcpV6MessageType::RENEW => {
+            DhcpV6MessageType::REQUEST
+            | DhcpV6MessageType::RENEW
+            | DhcpV6MessageType::RELEASE => {
                 if let Some(lease) = self.lease.as_ref() {
                     dhcp_msg
                         .opts_mut()

--- a/src/integ_tests/dhcpv4_async.rs
+++ b/src/integ_tests/dhcpv4_async.rs
@@ -52,6 +52,7 @@ fn test_dhcpv4_async() {
             // call to use_host_name_as_client_id(), then the server should
             // return FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID.
             assert_eq!(lease.yiaddr, FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID,);
+            cli.release(&lease).unwrap();
         }
     })
 }

--- a/src/integ_tests/dhcpv6_async.rs
+++ b/src/integ_tests/dhcpv6_async.rs
@@ -28,6 +28,7 @@ fn test_dhcpv6_async() {
             // call to use_host_name_as_client_id(), then the server should
             // return FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID.
             assert_eq!(lease.addr, FOO1_STATIC_IPV6);
+            cli.release(&lease).unwrap();
         }
     })
 }


### PR DESCRIPTION
Introducing these functions to release the lease:
 * `DhcpV6ClientAsync::release()`
 * `DhcpV4ClientAsync::release()`

If user want to get new release after lease been released, new instance
of DHCP Client should be created.

Example code and integration test cases updated.