### PR TITLE
dhcpv4: Replace the DiscoveryTimeout timer when discovery done

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -196,6 +196,7 @@ impl<T: DhcpEvent> DhcpEventPool<T> {
         if let Some(timer_fd) = self.timer_fds.remove(&event) {
             self.epoll.del_fd(timer_fd.as_raw_fd())?;
         }
+        log::debug!("Deleted timer {event} from event pool");
         Ok(())
     }
 


### PR DESCRIPTION
We should replace `DiscoveryTimeout` timer with `RequestTimeout` when
the discovery is done and entering request phase.

Manually tested by checking debug logs of
`cargo run --example mozim_dhcpv4_async`.

DHCPv6 part does not have this problem as it has only single retry timer
`DhcpV6Event::TransmitWait`.