### PR TITLE
Replace homepage field with repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "mozim"
 version = "0.2.5"
 description = "DHCP Client Library"
 license = "Apache-2.0"
-homepage = "https://github.com/nispor/mozim"
+repository = "https://github.com/nispor/mozim"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
The [`repository` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) is the preferred way of linking to a repository, while the `homepage` field is usually used for the homepage (if different from the repository link). Automated tools expect to find the repository link in `repository`. This PR fixes it.