### PR TITLE
DHCPv4: Support classless route

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ etherparse = "0.13.0"
 nix = { version = "0.29.0", features = ["poll", "time", "event"] }
 nispor = "1.2.17"
 futures = { version = "0.3", default-features = false, features = ["std"] }
+ipnet = "2.11.0"
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["macros", "rt"] }

--- a/src/dhcpv4/mod.rs
+++ b/src/dhcpv4/mod.rs
@@ -5,6 +5,7 @@ mod config;
 mod event;
 mod lease;
 mod msg;
+mod option;
 mod time;
 
 pub use self::client::DhcpV4Client;
@@ -12,3 +13,4 @@ pub use self::config::DhcpV4Config;
 pub use self::event::DhcpV4Event;
 pub use self::lease::DhcpV4Lease;
 pub use self::msg::{DhcpV4Message, DhcpV4MessageType};
+pub use self::option::DhcpV4ClasslessRoute;

--- a/src/dhcpv4/msg.rs
+++ b/src/dhcpv4/msg.rs
@@ -107,15 +107,9 @@ impl DhcpV4Message {
                 .insert(v4::DhcpOption::MessageType(v4::MessageType::Discover));
             dhcp_msg
                 .opts_mut()
-                .insert(v4::DhcpOption::ParameterRequestList(vec![
-                    v4::OptionCode::Hostname,
-                    v4::OptionCode::SubnetMask,
-                    v4::OptionCode::Router,
-                    v4::OptionCode::DomainNameServer,
-                    v4::OptionCode::DomainName,
-                    v4::OptionCode::InterfaceMtu,
-                    v4::OptionCode::NtpServers,
-                ]));
+                .insert(v4::DhcpOption::ParameterRequestList(
+                    self.config.request_opts.clone(),
+                ));
         } else if self.msg_type == DhcpV4MessageType::Request {
             dhcp_msg
                 .opts_mut()
@@ -149,15 +143,9 @@ impl DhcpV4Message {
             }
             dhcp_msg
                 .opts_mut()
-                .insert(v4::DhcpOption::ParameterRequestList(vec![
-                    v4::OptionCode::Hostname,
-                    v4::OptionCode::SubnetMask,
-                    v4::OptionCode::Router,
-                    v4::OptionCode::DomainNameServer,
-                    v4::OptionCode::DomainName,
-                    v4::OptionCode::InterfaceMtu,
-                    v4::OptionCode::NtpServers,
-                ]));
+                .insert(v4::DhcpOption::ParameterRequestList(
+                    self.config.request_opts.clone(),
+                ));
         } else if self.msg_type == DhcpV4MessageType::Release {
             if let Some(lease) = self.lease.as_ref() {
                 dhcp_msg.set_ciaddr(lease.yiaddr);

--- a/src/dhcpv4/option.rs
+++ b/src/dhcpv4/option.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+
+use dhcproto::{
+    v4::{DhcpOption, OptionCode},
+    Decodable, Encodable,
+};
+
+// Microsoft Classless Static Route Option, data format is identical to
+// RFC 3442: Classless Static Route Option(121)
+pub(crate) const V4_OPT_CODE_MS_CLASSLESS_STATIC_ROUTE: u8 = 249;
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub(crate) struct DhcpV4Options {
+    data: HashMap<u8, Vec<u8>>,
+}
+
+impl DhcpV4Options {
+    pub(crate) fn new<'a, T>(opts: T) -> Self
+    where
+        T: Iterator<Item = (&'a OptionCode, &'a DhcpOption)>,
+    {
+        let mut data = HashMap::new();
+        for (code, opt) in opts {
+            if let Ok(raw) = opt.to_vec() {
+                data.insert(u8::from(*code), raw);
+            }
+        }
+        Self { data }
+    }
+
+    pub(crate) fn get_data_raw(&self, code: u8) -> Option<&[u8]> {
+        self.data.get(&code).map(|v| v.as_slice())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct DhcpV4ClasslessRoute {
+    pub destination: Ipv4Addr,
+    pub prefix_length: u8,
+    pub router: Ipv4Addr,
+}
+
+impl DhcpV4ClasslessRoute {
+    pub(crate) fn parse_raw(mut raw: Vec<u8>) -> Option<Vec<Self>> {
+        if !raw.is_empty() {
+            raw[0] = OptionCode::ClasslessStaticRoute.into();
+            if let Ok(DhcpOption::ClasslessStaticRoute(v)) =
+                DhcpOption::decode(&mut dhcproto::Decoder::new(raw.as_slice()))
+            {
+                return Some(Self::parse(&v));
+            }
+        }
+        None
+    }
+
+    pub(crate) fn parse(rts: &[(ipnet::Ipv4Net, Ipv4Addr)]) -> Vec<Self> {
+        let mut ret = Vec::new();
+        for (dst, router) in rts {
+            ret.push(Self {
+                destination: dst.addr(),
+                prefix_length: dst.prefix_len(),
+                router: *router,
+            });
+        }
+        ret
+    }
+}

--- a/src/integ_tests/env.rs
+++ b/src/integ_tests/env.rs
@@ -15,6 +15,9 @@ const TEST_NIC_SRV: &str = "dhcpsrv";
 
 const TEST_DHCP_SRV_IP: &str = "192.0.2.1";
 const TEST_DHCP_SRV_IPV6: &str = "2001:db8:a::1";
+pub(crate) const TEST_CLS_DST: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 0);
+pub(crate) const TEST_CLS_DST_LEN: u8 = 24;
+pub(crate) const TEST_CLS_RT_ADDR: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 40);
 
 pub(crate) const FOO1_HOSTNAME: &str = "foo1";
 pub(crate) const FOO1_CLIENT_ID: &str =
@@ -86,6 +89,8 @@ fn start_dhcp_server() {
         --dhcp-option=option:mtu,1492
         --dhcp-option=option:domain-name,example.com
         --dhcp-option=option:ntp-server,192.0.2.1
+        --dhcp-option=121,{TEST_CLS_DST}/{TEST_CLS_DST_LEN},{TEST_CLS_RT_ADDR}
+        --dhcp-option=249,{TEST_CLS_DST}/{TEST_CLS_DST_LEN},{TEST_CLS_RT_ADDR}
         --bind-interfaces
         --except-interface=lo
         --clear-on-reload

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ mod integ_tests;
 
 pub use crate::client_async::{DhcpV4ClientAsync, DhcpV6ClientAsync};
 pub use crate::dhcpv4::{
-    DhcpV4Client, DhcpV4Config, DhcpV4Event, DhcpV4Lease, DhcpV4Message,
-    DhcpV4MessageType,
+    DhcpV4ClasslessRoute, DhcpV4Client, DhcpV4Config, DhcpV4Event, DhcpV4Lease,
+    DhcpV4Message, DhcpV4MessageType,
 };
 pub use crate::dhcpv6::{
     DhcpV6Client, DhcpV6Config, DhcpV6Event, DhcpV6IaType, DhcpV6Lease,

--- a/utils/test_env_mozim
+++ b/utils/test_env_mozim
@@ -38,6 +38,8 @@ sudo ip netns exec mozim dnsmasq \
     --dhcp-option=option:mtu,1492 \
     --dhcp-option=option:domain-name,example.com\
     --dhcp-option=option:ntp-server,${DHCP_SRV_IP} \
+    --dhcp-option=121,203.0.113.0/24,${IPV4_BLOCK}.40 \
+    --dhcp-option=249,203.0.113.0/24,${IPV4_BLOCK}.40 \
     --keep-in-foreground \
     --clear-on-reload \
     --interface=dhcpsrv \


### PR DESCRIPTION
Introducing:

```rust
DhcpV4Lease.classless_routes: Option<Vec<DhcpV4ClasslessRoute>>

struct DhcpV4ClasslessRoute {
    pub destination: Ipv4Addr,
    pub prefix_length: u8,
    pub router: Ipv4Addr,
}
```

It holding the content of DHCP option 121(RFC 3442) and 249 (Microsoft
clone of 121).

Also introduced these functions for advanced crate user:
 * `DhcpV4Config::request_extra_dhcp_opts()` -- Request extra DHCP option
   besides crate defaults.

 * `DhcpV4Config::override_request_dhcp_opts()` -- Specify arbitrary
   DHCP options to request.

 * `DhcpV4Lease::get_option_raw()` -- Get raw data of specified DHCP
   option containing both the leading code and length(if available).

Added new dependency -- ipnet which is already used by dhcproto, so no
impact at all.

Integration test case improved for this use case.

Manually tested with 121 and 249 option alone, both works well.