### PR TITLE
New release 0.2.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.2.7] - 2025-08-15
+### Breaking changes
+ - N/A
+
+### New features
+ - DHCPv4: Support classless route. (28e050c)
+
+### Bug fixes
+ - N/A
+
 ## [0.2.6] - 2025-05-28
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozim"
-version = "0.2.6"
+version = "0.2.7"
 description = "DHCP Client Library"
 license = "Apache-2.0"
 repository = "https://github.com/nispor/mozim"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - DHCPv4: Support classless route. (28e050c)

=== Bug fixes
 - N/A