### PR TITLE
dhcpv4: Do not double close RAW socket

### DIFF
--- a/src/dhcpv4/lease.rs
+++ b/src/dhcpv4/lease.rs
@@ -31,6 +31,9 @@ pub struct DhcpV4Lease {
     pub mtu: Option<u16>,
     pub host_name: Option<String>,
     pub domain_name: Option<String>,
+    /// According to RFC 3442, once `Classless Static Routes` option is
+    /// defined, DHCP client should ignore `Router` option. Hence if this
+    /// properties is defined(not None), please do not use `gateways` property.
     pub classless_routes: Option<Vec<DhcpV4ClasslessRoute>>,
     dhcp_opts: DhcpV4Options,
 }

--- a/src/dhcpv4/socket.rs
+++ b/src/dhcpv4/socket.rs
@@ -219,13 +219,10 @@ fn bind_raw_socket(
             std::mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
         ) {
             0 => Ok(()),
-            rc => {
-                libc::close(fd);
-                Err(DhcpError::new(
-                    ErrorKind::Bug,
-                    format!("Failed to bind socket: {rc}"),
-                ))
-            }
+            rc => Err(DhcpError::new(
+                ErrorKind::Bug,
+                format!("Failed to bind socket: {rc}"),
+            )),
         }
     }
 }


### PR DESCRIPTION
The RAW socket was created by `nix::sys::socket::socket()` as `OwnedFd`,
Rust document state `OwnedFd`:

    It is guaranteed that nobody else will close the file descriptor.

Hence we should not use `libc::close()` to close this socket.

Resolves: https://github.com/nispor/mozim/issues/76