### PR TITLE
Renew for dhcpv4 not working properly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           - rust_target: "loongarch64-unknown-linux-gnu"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install Rust Stable
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,9 +37,9 @@ jobs:
 
     steps:
     - name: Install packages
-      run:  sudo apt-get -y install dnsmasq
+      run:  sudo apt-get -y install dnsmasq busybox
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Install Rust stable
       run: rustup default stable

--- a/src/dhcpv4/client.rs
+++ b/src/dhcpv4/client.rs
@@ -197,7 +197,7 @@ impl DhcpV4Client {
                     DhcpUdpV4Socket::new(
                         self.config.iface_name.as_str(),
                         lease.yiaddr,
-                        lease.siaddr,
+                        lease.srv_id,
                     )
                     .await?,
                 );

--- a/src/dhcpv4/lease.rs
+++ b/src/dhcpv4/lease.rs
@@ -178,7 +178,9 @@ impl DhcpV4Lease {
                 "Invalid DHCP lease: T2 is bigger than lease time".to_string(),
             ));
         }
-
+        if self.srv_id.is_unspecified() {
+            log::warn!("Server identifier unspecified (Option 54). Check your DHCP server, unicast renew will not work");
+        }
         Ok(())
     }
 

--- a/src/integ_tests/dhcpv4.rs
+++ b/src/integ_tests/dhcpv4.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::env::{
-    init_log, with_dhcp_env, FOO1_HOSTNAME,
+    init_log, set_client_ip, with_dhcp_env, with_udhcpd_env, FOO1_HOSTNAME,
     FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID, TEST_CLS_DST, TEST_CLS_DST_LEN,
-    TEST_CLS_RT_ADDR, TEST_NIC_CLI,
+    TEST_CLS_RT_ADDR, TEST_DHCP_SRV_ADDR, TEST_NIC_CLI,
 };
 use crate::{
     DhcpV4ClasslessRoute, DhcpV4Client, DhcpV4Config, DhcpV4Lease, DhcpV4State,
 };
+use std::net::Ipv4Addr;
+use tokio::time::{timeout, Duration};
 
 const FOO2_HOSTNAME: &str = "foo2";
 
@@ -50,6 +52,68 @@ fn test_dhcpv4() {
             );
         }
     })
+}
+
+#[test]
+fn test_dhcpv4_unicast_renew_uses_srv_id() {
+    // test with udhcpd from busybox. Its a quite old server implementation
+    // but simple and reliable. It does not set siaddr automatically like
+    // dnsmasq which makes it a good candidate for a renew test so see that
+    // srv_id is used for the unicast renew and not siaddr.
+    init_log();
+
+    with_udhcpd_env(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .enable_io()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let cfg = DhcpV4Config::new(TEST_NIC_CLI);
+            let mut cli = DhcpV4Client::init(cfg, None).await.unwrap();
+
+            let lease = loop {
+                if let DhcpV4State::Done(l) = cli.run().await.unwrap() {
+                    break l;
+                }
+            };
+
+            assert_eq!(lease.srv_id, TEST_DHCP_SRV_ADDR);
+            assert_eq!(lease.yiaddr, Ipv4Addr::new(192, 0, 2, 100));
+            set_client_ip(lease.yiaddr);
+
+            // Wait until we are safely past T1 (50% lease time)
+            tokio::time::sleep(Duration::from_secs(6)).await;
+
+            // Renew phase
+            let state = cli.run().await.unwrap();
+            assert_eq!(state, DhcpV4State::Renewing);
+
+            // Observe outcome, timeout is fine, but we should never get so Rebinding
+            // (rebinding happens when renew fails, rebinding will use broadcast again like
+            // the first discovery)
+            let _ = timeout(Duration::from_secs(4), async {
+                loop {
+                    let state = cli.run().await.unwrap();
+
+                    match state {
+                        // Rebinding would happen on T2 = 85% lease time
+                        DhcpV4State::Rebinding => {
+                            panic!("entered Rebinding state – Renew via srv_id failed");
+                        }
+                        DhcpV4State::Renewing => {
+                            // still fine, keep polling
+                        }
+                        other => {
+                            log::debug!("Received unused dhcp state: {other:?}")
+                        }
+                    }
+                }
+            })
+            .await;
+        });
+    });
 }
 
 async fn get_lease() -> Option<DhcpV4Lease> {

--- a/src/integ_tests/env.rs
+++ b/src/integ_tests/env.rs
@@ -7,6 +7,8 @@ use std::{
     str::FromStr,
 };
 
+const UDHCPD_CONF: &str = "/tmp/mozim_test_udhcpd.conf";
+const UDHCPD_PID_FILE_PATH: &str = "/tmp/mozim_test_udhcpd.pid";
 const PID_FILE_PATH: &str = "/tmp/mozim_test_dnsmasq_pid";
 const TEST_DHCPD_NETNS: &str = "mozim_test";
 const LOG_FILE: &str = "/tmp/mozim_test_dnsmasq_log";
@@ -16,6 +18,7 @@ pub(crate) const TEST_PROXY_MAC1: &str = "00:11:22:33:44:55";
 const TEST_NIC_SRV: &str = "dhcpsrv";
 
 const TEST_DHCP_SRV_IP: &str = "192.0.2.1";
+pub(crate) const TEST_DHCP_SRV_ADDR: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
 const TEST_DHCP_SRV_IPV6: &str = "2001:db8:a::1";
 pub(crate) const TEST_CLS_DST: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 0);
 pub(crate) const TEST_CLS_DST_LEN: u8 = 24;
@@ -136,6 +139,71 @@ fn stop_dhcp_server() {
     run_cmd_ignore_failure(&format!("kill {pid}"));
 }
 
+fn write_udhcpd_conf() {
+    std::fs::write(
+        UDHCPD_CONF,
+        format!(
+            r#"
+start       192.0.2.100
+end         192.0.2.100
+interface   {TEST_NIC_SRV}
+
+option  subnet 255.255.255.0
+option  router {TEST_DHCP_SRV_IP}
+option  dns    8.8.8.8
+
+lease_file  /tmp/mozim_test_udhcpd.leases
+pidfile     /tmp/mozim_test_udhcpd.pid
+opt lease   10
+no_ping
+"#
+        ),
+    )
+    .unwrap();
+}
+
+fn start_udhcpd() {
+    write_udhcpd_conf();
+
+    Command::new("ip")
+        .args([
+            "netns",
+            "exec",
+            TEST_DHCPD_NETNS,
+            "busybox",
+            "udhcpd",
+            UDHCPD_CONF,
+        ])
+        .spawn()
+        .expect("Failed to start udhcpd")
+        .wait()
+        .ok();
+    // Need to wait 1 seconds for udhcpd to finish its start
+    std::thread::sleep(std::time::Duration::from_secs(1));
+}
+
+fn stop_udhcpd() {
+    if !std::path::Path::new(UDHCPD_PID_FILE_PATH).exists() {
+        log::warn!("PID file {UDHCPD_PID_FILE_PATH} does not exist");
+        return;
+    }
+    let mut fd =
+        std::fs::File::open(UDHCPD_PID_FILE_PATH).unwrap_or_else(|_| {
+            panic!("Failed to open {UDHCPD_PID_FILE_PATH} file")
+        });
+    let mut contents = String::new();
+    fd.read_to_string(&mut contents).unwrap_or_else(|_| {
+        panic!("Failed to read {UDHCPD_PID_FILE_PATH} file")
+    });
+
+    let pid = u32::from_str(contents.trim())
+        .unwrap_or_else(|_| panic!("Invalid PID content {contents}"));
+
+    run_cmd_ignore_failure(&format!("kill {pid}"));
+
+    run_cmd_ignore_failure("killall udhcpd");
+}
+
 fn run_cmd(cmd: &str) -> String {
     let cmds: Vec<&str> = cmd.split(' ').collect();
     String::from_utf8(
@@ -160,6 +228,10 @@ fn run_cmd_ignore_failure(cmd: &str) -> String {
     }
 }
 
+pub(crate) fn set_client_ip(address: Ipv4Addr) {
+    run_cmd(&format!("ip addr add {address}/24 dev {TEST_NIC_CLI}",));
+}
+
 pub(crate) fn with_dhcp_env<T>(test: T)
 where
     T: FnOnce() + std::panic::UnwindSafe,
@@ -177,6 +249,25 @@ where
     remove_test_veth_nics();
     remove_test_net_namespace();
     assert!(result.is_ok())
+}
+
+pub(crate) fn with_udhcpd_env<T>(test: T)
+where
+    T: FnOnce() + std::panic::UnwindSafe,
+{
+    create_test_net_namespace();
+    create_test_veth_nics();
+
+    stop_udhcpd();
+    start_udhcpd();
+
+    let result = std::panic::catch_unwind(test);
+
+    stop_udhcpd();
+    remove_test_veth_nics();
+    remove_test_net_namespace();
+
+    assert!(result.is_ok());
 }
 
 pub(crate) fn init_log() {


### PR DESCRIPTION
Renew is not working when I don't setup BOOTP. As far as I know, siaddr is only meant for BOOTP. Some DHCP servers might set that field. I did not so went into that. I think srv_id should be used.

Here is my log:
[2026-04-16T10:38:00Z INFO  embedded_networkmanager::dhcp4] Got lease DhcpV4Lease { srv_mac: [255, 255, 255, 255, 255, 255], siaddr: 0.0.0.0, yiaddr: 192.168.50.14, t1_sec: 60, t2_sec: 105, lease_time_sec: 120, srv_id: 192.168.50.1, subnet_mask: 255.255.255.0, broadcast_addr: Some(0.0.0.1), dns_srvs: Some([8.8.8.8]), gateways: Some([192.168.50.1]), ntp_srvs: None, mtu: None, host_name: None, domain_name: None, classless_routes: None, dhcp_opts: DhcpV4Options { data: {SubnetMask: SubnetMask(255.255.255.0), IpAddressLeaseTime: IpAddressLeaseTime(120), Router: Router([192.168.50.1]), ServerIdentifier: ServerIdentifier(192.168.50.1), DomainNameServer: DomainNameServer([8.8.8.8]), MessageType: MessageType(Ack), End: End, BroadcastAddress: BroadcastAddress(0.0.0.1)} } }
[2026-04-16T10:38:00Z DEBUG mozim::time] DHCP timer created TimerFd { fd: OwnedFd { fd: 10 } } with 59 seconds 993 milliseconds
[2026-04-16T10:38:00Z INFO  embedded_networkmanager::netlink::ipv4] replace_ipv4 on veth0: Ipv4Config { ip: Some(192.168.50.14), prefix: 24, gateways: Some([Gateway { ip: 192.168.50.1 }]) }
[2026-04-16T10:39:00Z INFO  embedded_networkmanager::dhcp4] DHCP state renewing
[2026-04-16T10:39:00Z DEBUG mozim::dhcpv4::socket] Creating UDP socket from 192.168.50.14:68 to 0.0.0.0:67
[2026-04-16T10:39:00Z DEBUG mozim::dhcpv4::socket] Finished UDP socket creation
[2026-04-16T10:39:00Z DEBUG mozim::dhcpv4::renew] Sending unicast DHCPREQUEST for renew
[2026-04-16T10:39:00Z DEBUG mozim::dhcpv4::renew] Waiting server reply with DHCPACK
[2026-04-16T10:39:45Z INFO  mozim::dhcpv4::renew] Timeout(44s) on waiting DHCP server DHCPACK reply for DHCPREQUEST renew, retrying
[2026-04-16T10:39:45Z DEBUG mozim::dhcpv4::renew] DHCP lease T2 expired, entering rebinding state