### PR TITLE
New release 0.3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,18 @@
 # Changelog
+## [0.3.2] - 2026-05-08
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - fix: Change UDP socket dest to srv_id and test with udhcpd. (834e71c)
+ - dhcpv4: Add document indicate option 121 obsolete option 33. (581bf28)
+ - dhcpv4: Do not double close RAW socket. (6416727)
+ - Use rtnetlink 0.20.0. (ac8985d)
+ - Use latest rtnetlink 0.19.0. (8590b2d)
+
 ## [0.3.1] - 2025-12-05
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozim"
-version = "0.3.1"
+version = "0.3.2"
 description = "DHCP Client Library"
 license = "Apache-2.0"
 repository = "https://github.com/nispor/mozim"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - fix: Change UDP socket dest to srv_id and test with udhcpd. (834e71c)
 - dhcpv4: Add document indicate option 121 obsolete option 33. (581bf28)
 - dhcpv4: Do not double close RAW socket. (6416727)
 - Use rtnetlink 0.20.0. (ac8985d)
 - Use latest rtnetlink 0.19.0. (8590b2d)