### PR TITLE
dhcpv4: Fix MS classless static route (option 249) fallback

### DIFF
--- a/src/dhcpv4/lease.rs
+++ b/src/dhcpv4/lease.rs
@@ -153,10 +153,12 @@ impl DhcpV4Lease {
         }
 
         if ret.classless_routes.is_none() {
-            if let Some(raw) = msg.options.get_data_raw(
-                DhcpV4OptionCode::MS_CLASSLESS_STATIC_ROUTE.into(),
-            ) {
-                if let Ok(v) = DhcpV4ClasslessRoutes::parse(raw.as_slice()) {
+            if let Some(DhcpV4Option::Unknown(unk_opt)) =
+                msg.options.get(DhcpV4OptionCode::MS_CLASSLESS_STATIC_ROUTE)
+            {
+                if let Ok(v) =
+                    DhcpV4ClasslessRoutes::parse(unk_opt.data.as_slice())
+                {
                     ret.classless_routes = Some(v);
                 }
             }
@@ -179,13 +181,16 @@ impl DhcpV4Lease {
             ));
         }
         if self.srv_id.is_unspecified() {
-            log::warn!("Server identifier unspecified (Option 54). Check your DHCP server, unicast renew will not work");
+            log::warn!(
+                "Server identifier unspecified (Option 54). Check your DHCP \
+                 server, unicast renew will not work"
+            );
         }
         Ok(())
     }
 
-    /// Return the raw data of specified DHCP option without
-    /// leading code and length.
+    /// Return the raw data of specified DHCP option containing
+    /// leading code and length(if available) also.
     pub fn get_option_raw(&self, code: u8) -> Option<Vec<u8>> {
         self.dhcp_opts.get_data_raw(code)
     }
@@ -208,6 +213,7 @@ fn add_jitter(val: u32) -> u32 {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::DhcpV4OptionUnknown;
 
     #[test]
     fn test_prefix_length() {
@@ -265,5 +271,44 @@ mod test {
             "t2 seconds {} outside of range 85..89",
             lease.t2_sec
         );
+    }
+
+    #[test]
+    fn test_dhcp_v4_lease_ms_classless_route() {
+        let mut opts = DhcpV4Options::new();
+        opts.insert(DhcpV4Option::IpAddressLeaseTime(100));
+        opts.insert(DhcpV4Option::Unknown(DhcpV4OptionUnknown {
+            code: u8::from(DhcpV4OptionCode::MS_CLASSLESS_STATIC_ROUTE),
+            data: vec![24, 203, 0, 113, 192, 0, 2, 40],
+        }));
+        let msg = DhcpV4Message {
+            options: opts,
+            ..Default::default()
+        };
+        let lease = DhcpV4Lease::new_from_msg(&msg).unwrap();
+        assert_eq!(
+            lease.classless_routes,
+            Some(vec![DhcpV4ClasslessRoute {
+                destination: Ipv4Addr::new(203, 0, 113, 0),
+                prefix_length: 24,
+                router: Ipv4Addr::new(192, 0, 2, 40),
+            }])
+        );
+    }
+
+    #[test]
+    fn test_dhcp_v4_lease_ms_classless_route_invalid_prefix() {
+        let mut opts = DhcpV4Options::new();
+        opts.insert(DhcpV4Option::IpAddressLeaseTime(100));
+        opts.insert(DhcpV4Option::Unknown(DhcpV4OptionUnknown {
+            code: u8::from(DhcpV4OptionCode::MS_CLASSLESS_STATIC_ROUTE),
+            data: vec![33, 203, 0, 113, 192, 0, 2, 40],
+        }));
+        let msg = DhcpV4Message {
+            options: opts,
+            ..Default::default()
+        };
+        let lease = DhcpV4Lease::new_from_msg(&msg).unwrap();
+        assert_eq!(lease.classless_routes, None);
     }
 }

--- a/src/dhcpv4/option.rs
+++ b/src/dhcpv4/option.rs
@@ -3,7 +3,7 @@
 use std::{cmp::Ordering, collections::HashMap, net::Ipv4Addr};
 
 use super::msg::DhcpV4MessageType;
-use crate::{Buffer, BufferMut, DhcpError, ErrorContext};
+use crate::{Buffer, BufferMut, DhcpError, ErrorContext, ErrorKind};
 
 /// DHCPv4 Option code(u8) defined by RFC 2132
 #[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
@@ -492,7 +492,16 @@ impl DhcpV4ClasslessRoute {
                 buf.get_u8().context(err_str)?,
                 0,
             ),
-            _ => buf.get_ipv4().context(err_str)?,
+            25..=32 => buf.get_ipv4().context(err_str)?,
+            _ => {
+                return Err(DhcpError::new(
+                    ErrorKind::InvalidDhcpMessage,
+                    format!(
+                        "Invalid DHCPv4 classless static route prefix length \
+                         {prefix_length}, should be 0 - 32"
+                    ),
+                ));
+            }
         };
 
         Ok(Self {
@@ -551,4 +560,53 @@ impl DhcpV4ClasslessRoutes {
 pub struct DhcpV4OptionUnknown {
     pub code: u8,
     pub data: Vec<u8>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_classless_route_reject_prefix_over_32() {
+        assert!(DhcpV4ClasslessRoutes::parse(&[
+            33, 203, 0, 113, 192, 0, 2, 40
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn test_parse_classless_routes() {
+        // default route via 192.0.2.1 + 203.0.113.0/24 via 192.0.2.40
+        assert_eq!(
+            DhcpV4ClasslessRoutes::parse(&[
+                0, 192, 0, 2, 1, 24, 203, 0, 113, 192, 0, 2, 40
+            ])
+            .unwrap(),
+            vec![
+                DhcpV4ClasslessRoute {
+                    destination: Ipv4Addr::UNSPECIFIED,
+                    prefix_length: 0,
+                    router: Ipv4Addr::new(192, 0, 2, 1),
+                },
+                DhcpV4ClasslessRoute {
+                    destination: Ipv4Addr::new(203, 0, 113, 0),
+                    prefix_length: 24,
+                    router: Ipv4Addr::new(192, 0, 2, 40),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_get_data_raw_with_code_and_length() {
+        let mut opts = DhcpV4Options::new();
+        opts.insert(DhcpV4Option::Unknown(DhcpV4OptionUnknown {
+            code: 249,
+            data: vec![24, 203, 0, 113, 192, 0, 2, 40],
+        }));
+        assert_eq!(
+            opts.get_data_raw(249).unwrap(),
+            vec![249, 8, 24, 203, 0, 113, 192, 0, 2, 40]
+        );
+    }
 }


### PR DESCRIPTION
Problem:

Given a DHCPv4 client talking to a server that only sends the
Microsoft classless static route option (249) instead of the
standard one (121), e.g. Windows Server DHCP
When the lease is built from the reply
Then `DhcpV4Lease::classless_routes` stays None, so the routes are
silently dropped.

Root cause:

The fallback fed `DhcpV4Options::get_data_raw()` output into
`DhcpV4ClasslessRoutes::parse()`. But `get_data_raw()` returns the
option prefixed with its code and length bytes, while the parser
expects the bare route payload. It therefore read the option code
(249) as a route prefix length and failed. The original dhcproto
based implementation parsed the payload only, so this regressed
during the rewrite to our own parser.

Fix:

Read the payload directly from the stored `DhcpV4Option::Unknown`
variant, matching the original behavior. Also reject classless
route prefix lengths above 32 instead of misparsing them, and
correct the `get_option_raw()` doc which wrongly claimed the code
and length were stripped.

Unit test cases included.