### PR TITLE
dhcpv4: Fix DHCPRELEASE being ignored by DHCP servers

### DIFF
--- a/src/dhcpv4/msg.rs
+++ b/src/dhcpv4/msg.rs
@@ -389,9 +389,22 @@ impl DhcpV4Message {
         config: &DhcpV4Config,
         lease: &DhcpV4Lease,
     ) -> Self {
-        let mut ret = Self::new_request(xid, config, lease);
+        // RFC 2131 4.4.1: DHCPRELEASE carries the released address in
+        // ciaddr (servers like dnsmasq/udhcpd look up the lease by
+        // ciaddr), plus server identifier and client identifier.
+        // Do not reuse new_request(): its `RequestedIpAddress` option
+        // makes dnsmasq zero ciaddr and drop the release silently.
+        let mut ret = Self::new(xid, config);
+        ret.ciaddr = lease.yiaddr;
         ret.options
             .insert(DhcpV4Option::MessageType(DhcpV4MessageType::Release));
+        if lease.srv_id != Ipv4Addr::UNSPECIFIED {
+            ret.options
+                .insert(DhcpV4Option::ServerIdentifier(lease.srv_id));
+        } else {
+            ret.options
+                .insert(DhcpV4Option::ServerIdentifier(lease.siaddr));
+        }
         ret
     }
 
@@ -458,4 +471,52 @@ fn gen_eth_packet(
     })?;
 
     Ok(packet)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_release_msg() {
+        let mut config = DhcpV4Config::new("eth1");
+        config
+            .set_iface_mac_raw(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x01])
+            .unwrap()
+            .use_mac_as_client_id();
+        let mut opts = DhcpV4Options::new();
+        opts.insert(DhcpV4Option::IpAddressLeaseTime(100));
+        opts.insert(DhcpV4Option::ServerIdentifier(Ipv4Addr::new(
+            192, 0, 2, 1,
+        )));
+        let lease = DhcpV4Lease::new_from_msg(&DhcpV4Message {
+            yiaddr: Ipv4Addr::new(192, 0, 2, 115),
+            options: opts,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let msg = DhcpV4Message::new_release(0x20260823, &config, &lease);
+
+        // RFC 2131 4.4.1: the released address must be in ciaddr,
+        // otherwise the server cannot find the lease.
+        assert_eq!(msg.ciaddr, lease.yiaddr);
+        assert_eq!(msg.message_type(), Some(DhcpV4MessageType::Release));
+        assert_eq!(
+            msg.options.get(DhcpV4OptionCode::ServerIdentifier),
+            Some(&DhcpV4Option::ServerIdentifier(lease.srv_id))
+        );
+        // dnsmasq zeroes ciaddr when the Requested IP Address option is
+        // present and then silently drops the RELEASE.
+        assert!(msg
+            .options
+            .get(DhcpV4OptionCode::RequestedIpAddress)
+            .is_none());
+        assert_eq!(
+            DhcpV4Message::parse(&msg.to_dhcp_packet().unwrap())
+                .unwrap()
+                .ciaddr,
+            lease.yiaddr
+        );
+    }
 }

--- a/src/integ_tests/dhcpv4.rs
+++ b/src/integ_tests/dhcpv4.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::net::Ipv4Addr;
+
+use tokio::time::{timeout, Duration};
+
 use super::env::{
     init_log, set_client_ip, with_dhcp_env, with_udhcpd_env, FOO1_HOSTNAME,
     FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID, TEST_CLS_DST, TEST_CLS_DST_LEN,
@@ -8,8 +12,6 @@ use super::env::{
 use crate::{
     DhcpV4ClasslessRoute, DhcpV4Client, DhcpV4Config, DhcpV4Lease, DhcpV4State,
 };
-use std::net::Ipv4Addr;
-use tokio::time::{timeout, Duration};
 
 const FOO2_HOSTNAME: &str = "foo2";
 
@@ -90,8 +92,9 @@ fn test_dhcpv4_unicast_renew_uses_srv_id() {
             let state = cli.run().await.unwrap();
             assert_eq!(state, DhcpV4State::Renewing);
 
-            // Observe outcome, timeout is fine, but we should never get so Rebinding
-            // (rebinding happens when renew fails, rebinding will use broadcast again like
+            // Observe outcome, timeout is fine, but we should never get so
+            // Rebinding (rebinding happens when renew fails,
+            // rebinding will use broadcast again like
             // the first discovery)
             let _ = timeout(Duration::from_secs(4), async {
                 loop {
@@ -100,7 +103,10 @@ fn test_dhcpv4_unicast_renew_uses_srv_id() {
                     match state {
                         // Rebinding would happen on T2 = 85% lease time
                         DhcpV4State::Rebinding => {
-                            panic!("entered Rebinding state – Renew via srv_id failed");
+                            panic!(
+                                "entered Rebinding state – Renew via srv_id \
+                                 failed"
+                            );
                         }
                         DhcpV4State::Renewing => {
                             // still fine, keep polling


### PR DESCRIPTION
Problem:

Given a DHCPv4 client holding a lease from a server (e.g. dnsmasq
or udhcpd)
When `DhcpV4Client::release()` sends the DHCPRELEASE message
Then the server ignores the release and keeps the lease: dnsmasq
2.93 logs no DHCPRELEASE line at all and the lease file keeps the
entry.

Root cause:

`DhcpV4Message::new_release()` was built on `new_request()` and
inherited two problems. It never set `ciaddr`, so the released
address was not carried as RFC 2131 section 4.4.1 requires and the
server could not look up the lease. It also carried the
`RequestedIpAddress` option (50); dnsmasq zeroes `ciaddr` whenever
that option is present ("buggy clients" workaround) and then drops
the RELEASE silently, so setting `ciaddr` alone was not enough.

Fix:

Build the RELEASE from `new()` instead of `new_request()`: set
`ciaddr` to the released address and only include the message type,
server identifier and client identifier as RFC 2131 section 4.4.1
expects. Verified against dnsmasq 2.93 in a network namespace: the
release is logged and the lease removed from the lease file.

Unit test case included.