### PR TITLE
dhcpv4: Fix hang when release lease on down interface

### DIFF
--- a/src/dhcpv4/socket.rs
+++ b/src/dhcpv4/socket.rs
@@ -131,21 +131,34 @@ impl DhcpV4Socket for DhcpRawSocket {
         while sent < eth_packet.len() {
             let mut guard = self.fd.writable().await?;
 
-            let _ = guard
-                .try_io(|inner| {
-                    sent += nix::sys::socket::send(
-                        inner.get_ref().as_raw_fd(),
-                        &eth_packet[sent..],
-                        MsgFlags::empty(),
-                    )?;
-                    Ok(())
-                })
-                .map_err(|e| {
-                    DhcpError::new(
+            // `try_io()` returns `Ok(Err(_))` for every error except
+            // `WouldBlock`; discarding it would hide persistent send
+            // failures and spin the loop.
+            match guard.try_io(|inner| {
+                let n = nix::sys::socket::send(
+                    inner.get_ref().as_raw_fd(),
+                    &eth_packet[sent..],
+                    MsgFlags::empty(),
+                )?;
+                Ok(n)
+            }) {
+                Ok(Ok(0)) => {
+                    return Err(DhcpError::new(
                         ErrorKind::IoError,
-                        format!("Failed to send packet to raw socket: {e:?}"),
-                    )
-                })?;
+                        "Raw socket send made no progress".to_string(),
+                    ));
+                }
+                Ok(Ok(n)) => sent += n,
+                Ok(Err(e)) => {
+                    return Err(DhcpError::new(
+                        ErrorKind::IoError,
+                        format!("Failed to send packet to raw socket: {e}"),
+                    ));
+                }
+                // WouldBlock: `try_io()` already cleared the readiness,
+                // wait for the next writable event.
+                Err(_) => continue,
+            }
         }
 
         Ok(())

--- a/src/integ_tests/dhcpv4_proxy.rs
+++ b/src/integ_tests/dhcpv4_proxy.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 use super::env::{
-    init_log, with_dhcp_env, TEST_NIC_CLI, TEST_PROXY_IP1, TEST_PROXY_MAC1,
+    init_log, set_client_nic_down, with_dhcp_env, TEST_NIC_CLI, TEST_PROXY_IP1,
+    TEST_PROXY_MAC1,
 };
 use crate::{DhcpV4Client, DhcpV4Config, DhcpV4Lease, DhcpV4State};
 
@@ -21,6 +24,47 @@ fn test_dhcpv4_proxy() {
         if let Some(lease) = lease {
             assert_eq!(lease.yiaddr, TEST_PROXY_IP1);
         }
+    })
+}
+
+#[test]
+fn test_dhcpv4_proxy_release_error_on_down_iface() {
+    init_log();
+    with_dhcp_env(|| {
+        let (tx, rx) = std::sync::mpsc::channel();
+        // The release runs on its own thread: the pre-fix `send()`
+        // spins forever on the discarded error, which would starve
+        // any tokio timeout on a current-thread runtime. This way
+        // the test fails with `recv_timeout()` instead of hanging.
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .enable_io()
+                .build()
+                .unwrap();
+            let result = rt.block_on(async {
+                let config =
+                    DhcpV4Config::new_proxy(TEST_NIC_CLI, TEST_PROXY_MAC1)
+                        .unwrap();
+                let mut cli = DhcpV4Client::init(config, None).await.unwrap();
+
+                let lease = loop {
+                    if let DhcpV4State::Done(l) = cli.run().await.unwrap() {
+                        break l;
+                    }
+                };
+
+                set_client_nic_down();
+
+                cli.release(&lease).await
+            });
+            let _ = tx.send(result);
+        });
+
+        let result = rx.recv_timeout(Duration::from_secs(20));
+        // Before the fix, `DhcpRawSocket::send()` discarded the
+        // send error and kept spinning, so no result ever arrived.
+        assert!(matches!(result, Ok(Err(_))));
     })
 }
 

--- a/src/integ_tests/env.rs
+++ b/src/integ_tests/env.rs
@@ -232,6 +232,10 @@ pub(crate) fn set_client_ip(address: Ipv4Addr) {
     run_cmd(&format!("ip addr add {address}/24 dev {TEST_NIC_CLI}",));
 }
 
+pub(crate) fn set_client_nic_down() {
+    run_cmd(&format!("ip link set {TEST_NIC_CLI} down"));
+}
+
 pub(crate) fn with_dhcp_env<T>(test: T)
 where
     T: FnOnce() + std::panic::UnwindSafe,


### PR DESCRIPTION
Problem:

Given the client sends a packet via `DhcpRawSocket::send()`
When the raw socket fails persistently (e.g. interface down)
Then the error is discarded and the send loop spins forever,
starving any tokio timeout.

Root cause:

`try_io()` reports persistent send errors as `Ok(Err(_))`, but the
old code discarded that result with `let _`, so the loop kept
retrying the same bytes.

Fix:

Return persistent errors as `DhcpError`, fail on a zero-progress
send, and on `WouldBlock` wait for the next writable event.

Integration test `test_dhcpv4_proxy_release_error_on_down_iface`
included.