### PR TITLE
dhcpv4: Fix parse_mac() accepting wrong MAC length

### DIFF
--- a/src/dhcpv4/config.rs
+++ b/src/dhcpv4/config.rs
@@ -134,25 +134,13 @@ impl DhcpV4Config {
         out_iface_name: &str,
         proxy_mac: &str,
     ) -> Result<Self, DhcpError> {
-        let mac = parse_mac(proxy_mac)?;
-        if mac.len() != ETH_ALEN {
-            Err(DhcpError::new(
-                ErrorKind::NotSupported,
-                format!(
-                    "Supported MAC address {proxy_mac}, expecting format \
-                     01:02:2a:2c:f7:04"
-                ),
-            ))
-        } else {
-            let mut src_mac = [0; ETH_ALEN];
-            src_mac.copy_from_slice(&mac[..ETH_ALEN]);
-            Ok(Self {
-                iface_name: out_iface_name.to_string(),
-                src_mac: Some(src_mac),
-                is_proxy: true,
-                ..Default::default()
-            })
-        }
+        let src_mac = parse_mac(proxy_mac)?;
+        Ok(Self {
+            iface_name: out_iface_name.to_string(),
+            src_mac: Some(src_mac),
+            is_proxy: true,
+            ..Default::default()
+        })
     }
 
     pub fn set_host_name(&mut self, host_name: &str) -> &mut Self {
@@ -266,5 +254,25 @@ mod test {
         config.set_iface_index(2);
         config.set_iface_mac_raw(&TEST_MAC).unwrap();
         assert!(!config.need_resolve());
+    }
+
+    #[test]
+    fn test_set_iface_mac() {
+        let mut config = DhcpV4Config::new("eth1");
+        config.set_iface_mac("01:02:2a:2c:f7:04").unwrap();
+        assert_eq!(config.src_mac, Some([0x01, 0x02, 0x2a, 0x2c, 0xf7, 0x04]));
+        let mut config = DhcpV4Config::new("eth1");
+        assert!(config.set_iface_mac("01:02:2a:2c:f7").is_err());
+        assert!(config.set_iface_mac("01:02:2a:2c:f7:04:05").is_err());
+    }
+
+    #[test]
+    fn test_new_proxy_mac() {
+        let config =
+            DhcpV4Config::new_proxy("eth1", "01:02:2a:2c:f7:04").unwrap();
+        assert!(config.is_proxy);
+        assert_eq!(config.src_mac, Some([0x01, 0x02, 0x2a, 0x2c, 0xf7, 0x04]));
+        assert!(DhcpV4Config::new_proxy("eth1", "01:02:2a:2c:f7").is_err());
+        assert!(DhcpV4Config::new_proxy("eth1", "0g:02:2a:2c:f7:04").is_err());
     }
 }

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -4,21 +4,60 @@ use crate::{DhcpError, ErrorKind, ETH_ALEN};
 
 pub(crate) const BROADCAST_MAC_ADDRESS: [u8; ETH_ALEN] = [u8::MAX; ETH_ALEN];
 
-pub(crate) fn parse_mac(mac: &str) -> Result<Vec<u8>, DhcpError> {
-    let mut mac_bytes = Vec::new();
-    for item in mac.split(':') {
-        match u8::from_str_radix(item, 16) {
-            Ok(i) => mac_bytes.push(i),
-            Err(_) => {
-                return Err(DhcpError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "Invalid MAC address {mac}, expecting format \
-                         01:02:2a:2c:f7:04"
-                    ),
-                ));
-            }
+fn invalid_mac_err(mac: &str) -> DhcpError {
+    DhcpError::new(
+        ErrorKind::InvalidArgument,
+        format!(
+            "Invalid MAC address {mac}, expecting format 01:02:2a:2c:f7:04"
+        ),
+    )
+}
+
+pub(crate) fn parse_mac(mac: &str) -> Result<[u8; ETH_ALEN], DhcpError> {
+    let mut items = mac.split(':');
+    let mut mac_bytes = [0u8; ETH_ALEN];
+    for slot in &mut mac_bytes {
+        match items
+            .next()
+            .and_then(|item| u8::from_str_radix(item, 16).ok())
+        {
+            Some(i) => *slot = i,
+            None => return Err(invalid_mac_err(mac)),
         }
     }
+    if items.next().is_some() {
+        return Err(invalid_mac_err(mac));
+    }
     Ok(mac_bytes)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_mac_valid() {
+        assert_eq!(
+            parse_mac("01:02:2a:2c:f7:04").unwrap(),
+            [0x01, 0x02, 0x2a, 0x2c, 0xf7, 0x04]
+        );
+        assert_eq!(
+            parse_mac("AA:BB:CC:DD:EE:FF").unwrap(),
+            [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]
+        );
+    }
+
+    #[test]
+    fn test_parse_mac_rejects_wrong_byte_count() {
+        assert!(parse_mac("01:02:2a:2c:f7").is_err());
+        assert!(parse_mac("01:02:2a:2c:f7:04:05").is_err());
+        assert!(parse_mac("").is_err());
+        assert!(parse_mac("01::04").is_err());
+    }
+
+    #[test]
+    fn test_parse_mac_rejects_invalid_hex() {
+        assert!(parse_mac("01:02:2a:2c:f7:ZZ").is_err());
+        assert!(parse_mac("gg:02:2a:2c:f7:04").is_err());
+    }
 }


### PR DESCRIPTION
Previously, `parse_mac()` only validated hex digits and returned
`Vec<u8>`, so the `ETH_ALEN` length invariant was not enforced by the
helper.

Patches to raise `ErrorKind::InvalidArgument` if not parsed into
`[0u8; ETH_ALEN]`

Unit tests included.