### PR TITLE
dhcpv4: Fix BPF fragment check and document VLAN limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ sudo ./utils/test_env_mozim &
 cargo run --example mozim_dhcpv4
 cargo run --example mozim_dhcpv6
 ```
+
+## Known issues
+
+* Mozim does not support VLAN interfaces created with `reorder_hdr off`.
+  DHCP over VLAN is only supported with the default `reorder_hdr on`,
+  where the kernel strips the VLAN tag before delivering frames to the
+  raw socket.

--- a/src/dhcpv4/bpf.rs
+++ b/src/dhcpv4/bpf.rs
@@ -45,8 +45,9 @@ const BPF_FILTER_RAW: [(u16, u8, u8, u32); DHCP_BPF_LEN as usize] = [
     (BPF_JMP | BPF_JEQ | BPF_K, 0, 6, IPPROTO_UDP),
     // Load IPv4 flag and fragment offset
     (BPF_LD | BPF_H | BPF_ABS, 0, 0, IP_FRAGMENT_POS),
-    // Drop package which has MF(more fragment) set is 1 or is fragment
-    (BPF_JMP | BPF_JSET | BPF_K, 4, 0, 0x1fff),
+    // Drop packet which has MF (more fragments) set or has a nonzero
+    // fragment offset.
+    (BPF_JMP | BPF_JSET | BPF_K, 4, 0, 0x3fff),
     // Store IP header length to X
     (BPF_LDX | BPF_B | BPF_MSH, 0, 0, IP_HEADER_LEN_POS),
     // Load UDP destination port number to A
@@ -106,5 +107,114 @@ pub(crate) fn apply_dhcp_bpf(fd: libc::c_int) -> Result<(), DhcpError> {
         Err(e)
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const CLASS_LD: u16 = 0x00;
+    const CLASS_LDX: u16 = 0x01;
+    const CLASS_JMP: u16 = 0x05;
+    const CLASS_RET: u16 = 0x06;
+
+    const MODE_ABS: u16 = 0x20;
+    const MODE_IND: u16 = 0x40;
+    const MODE_MSH: u16 = 0xa0;
+
+    const SIZE_B: u16 = 0x10;
+    const SIZE_H: u16 = 0x08;
+
+    fn load_h(packet: &[u8], offset: usize) -> u32 {
+        if offset + 2 > packet.len() {
+            0
+        } else {
+            u16::from_be_bytes([packet[offset], packet[offset + 1]]) as u32
+        }
+    }
+
+    fn run_filter(filter: &[(u16, u8, u8, u32)], packet: &[u8]) -> u32 {
+        let mut pc = 0usize;
+        let mut a = 0u32;
+        let mut x = 0u32;
+
+        while pc < filter.len() {
+            let (code, jt, jf, k) = filter[pc];
+            let class = code & 0x07;
+            let size = code & 0x18;
+            let mode = code & 0xe0;
+
+            match class {
+                CLASS_LD if mode == MODE_ABS && size == SIZE_B => {
+                    a = *packet.get(k as usize).unwrap_or(&0) as u32;
+                }
+                CLASS_LD if mode == MODE_ABS && size == SIZE_H => {
+                    a = load_h(packet, k as usize);
+                }
+                CLASS_LD if mode == MODE_IND && size == SIZE_H => {
+                    a = load_h(packet, (x + k) as usize);
+                }
+                CLASS_LDX if mode == MODE_MSH => {
+                    x = (*packet.get(k as usize).unwrap_or(&0) as u32 & 0x0f)
+                        << 2;
+                }
+                CLASS_JMP if code & 0xf0 == BPF_JEQ => {
+                    pc += 1;
+                    if a == k {
+                        pc += jt as usize;
+                    } else {
+                        pc += jf as usize;
+                    }
+                    continue;
+                }
+                CLASS_JMP if code & 0xf0 == BPF_JSET => {
+                    pc += 1;
+                    if a & k != 0 {
+                        pc += jt as usize;
+                    } else {
+                        pc += jf as usize;
+                    }
+                    continue;
+                }
+                CLASS_RET => return k,
+                _ => return 0,
+            }
+            pc += 1;
+        }
+        0
+    }
+
+    fn dhcp_frame(frag_bytes: [u8; 2]) -> Vec<u8> {
+        let mut frame = vec![0u8; 300];
+        frame[12..14].copy_from_slice(&[0x08, 0x00]);
+        frame[14] = 0x45;
+        frame[20..22].copy_from_slice(&frag_bytes);
+        frame[23] = IPPROTO_UDP as u8;
+        frame[36..38].copy_from_slice(&[0x00, 0x44]);
+        frame
+    }
+
+    #[test]
+    fn test_filter_accepts_udp_dhcp_packet() {
+        assert_eq!(run_filter(&BPF_FILTER_RAW, &dhcp_frame([0, 0])), u32::MAX);
+    }
+
+    #[test]
+    fn test_filter_rejects_mf_set_packet() {
+        assert_eq!(run_filter(&BPF_FILTER_RAW, &dhcp_frame([0x20, 0])), 0);
+    }
+
+    #[test]
+    fn test_filter_rejects_nonzero_fragment_offset() {
+        assert_eq!(run_filter(&BPF_FILTER_RAW, &dhcp_frame([0, 1])), 0);
+    }
+
+    #[test]
+    fn test_filter_accepts_df_set_packet() {
+        assert_eq!(
+            run_filter(&BPF_FILTER_RAW, &dhcp_frame([0x40, 0])),
+            u32::MAX
+        );
     }
 }


### PR DESCRIPTION
Problem:

When DHCPv4 runs over VLAN, the kernel strips the VLAN tag before
delivering frames to the raw socket with the default reorder_hdr on.
The BPF filter only rejected nonzero fragment offsets, allowing packets
with the MF bit set through.

Root cause:

0x1fff only covers the 13-bit fragment offset; the MF bit is 0x2000,
so a first fragment with MF set passed the filter.

Fix:

Use 0x3fff so packets with MF set or a nonzero fragment offset are
dropped. Document that VLAN interfaces with reorder_hdr off are not
supported.

Unit tests included.