### PR TITLE
dhcpv6: support search domain and NTP servers in lease

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,22 @@
+1. `add_jitter()` doc says -2..+2s but the code yields
+   -2..+1.
+2. Explicit T1/T2 option values of 0 pass `validate()` and
+   produce an immediate-renew loop; only ordering is checked.
+3. `new_request()` (`src/dhcpv4/msg.rs`) inserts
+   `ServerIdentifier` twice: first unconditionally, then again in
+   the `srv_id != UNSPECIFIED` branch. Harmless on the wire
+   (`DhcpV4Options::insert()` is a `HashMap` insert keyed by option
+   code, second overwrites first), but the unconditional insert is
+   dead code.
+4. Lacking integration test without `netlink` feature. The
+   4 netns integ tests create clients by interface name only and
+   `unwrap()` on `init()`, which needs `resolve()`; built with
+   `--no-default-features` they all fail. CI only runs
+   `cargo build --no-default-features` (never tests), so the gap is
+   invisible. Options: gate those tests on `feature = "netlink"`,
+   or add an integ test using manual `set_iface_index()` +
+   `set_iface_mac_raw()` to cover the no-netlink path.
+5. DHCPv6 domain names reject RFC 1035 compressed/pointer-style
+   labels (RFC 1035 section 4.1.4); parsing returns
+   `InvalidDhcpMessage` when the high two bits of a label length
+   are set.

--- a/src/dhcpv6/lease.rs
+++ b/src/dhcpv6/lease.rs
@@ -5,7 +5,7 @@ use std::{net::Ipv6Addr, time::Duration};
 use super::{msg::DhcpV6Message, option::DhcpV6Options};
 use crate::{
     DhcpError, DhcpV6Duid, DhcpV6IaType, DhcpV6Option, DhcpV6OptionCode,
-    ErrorKind,
+    DhcpV6OptionNtpServer, ErrorKind,
 };
 
 // Section 5 of RFC4941, one week
@@ -29,7 +29,11 @@ pub struct DhcpV6Lease {
     pub cli_duid: DhcpV6Duid,
     pub srv_duid: DhcpV6Duid,
     pub srv_ip: Ipv6Addr,
+    /// NTP servers from OPTION_NTP_SERVER (RFC 5908). Addresses are
+    /// strings; FQDNs are kept as received.
     pub ntp_srvs: Vec<String>,
+    /// Domain search list from OPTION_DOMAIN_LIST (RFC 3646).
+    pub domain_list: Vec<String>,
     dhcp_opts: DhcpV6Options,
 }
 
@@ -50,6 +54,7 @@ impl Default for DhcpV6Lease {
             dhcp_opts: DhcpV6Options::default(),
             srv_ip: Ipv6Addr::UNSPECIFIED,
             ntp_srvs: Vec::new(),
+            domain_list: Vec::new(),
         }
     }
 }
@@ -201,6 +206,30 @@ impl DhcpV6Lease {
         {
             ret.srv_ip = *srv_ip;
         }
+        if let Some(DhcpV6Option::NtpServer(srvs)) =
+            msg.options.get_first(DhcpV6OptionCode::NtpServer)
+        {
+            ret.ntp_srvs = srvs
+                .iter()
+                .filter_map(|srv| match srv {
+                    DhcpV6OptionNtpServer::ServerAddr(ip) => {
+                        Some(ip.to_string())
+                    }
+                    DhcpV6OptionNtpServer::MulticastAddr(ip) => {
+                        Some(ip.to_string())
+                    }
+                    DhcpV6OptionNtpServer::ServerFqdn(fqdn) => {
+                        Some(fqdn.clone())
+                    }
+                    DhcpV6OptionNtpServer::Other(..) => None,
+                })
+                .collect();
+        }
+        if let Some(DhcpV6Option::DomainList(domains)) =
+            msg.options.get_first(DhcpV6OptionCode::DomainList)
+        {
+            ret.domain_list = domains.clone();
+        }
         if let Some(DhcpV6Option::StatusCode(v)) =
             msg.options.get_first(DhcpV6OptionCode::StatusCode)
         {
@@ -267,5 +296,58 @@ impl DhcpV6Lease {
             ));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::Ipv6Addr;
+
+    use super::*;
+    use crate::{
+        dhcpv6::msg::DhcpV6MessageType, DhcpV6OptionIaAddr, DhcpV6OptionIaNa,
+    };
+
+    #[test]
+    fn lease_reads_ntp_fqdn_and_domain_list() {
+        let mut msg = DhcpV6Message {
+            msg_type: DhcpV6MessageType::Advertise,
+            ..Default::default()
+        };
+        msg.options
+            .insert(DhcpV6Option::ClientId(DhcpV6Duid::Raw(vec![1])));
+        msg.options
+            .insert(DhcpV6Option::ServerId(DhcpV6Duid::Raw(vec![2])));
+        msg.options.insert(DhcpV6Option::DomainList(vec![
+            "example.com".to_string(),
+            "example.org".to_string(),
+        ]));
+        msg.options.insert(DhcpV6Option::NtpServer(vec![
+            DhcpV6OptionNtpServer::ServerFqdn("ntp.example.com".to_string()),
+            DhcpV6OptionNtpServer::ServerFqdn("ntp2.example.com".to_string()),
+        ]));
+        msg.options.insert(DhcpV6Option::IANA(DhcpV6OptionIaNa::new(
+            1,
+            60,
+            90,
+            DhcpV6OptionIaAddr::new(
+                Ipv6Addr::new(0x2001, 0x0db8, 0x000a, 0, 0, 0, 0, 0x99),
+                120,
+                240,
+            ),
+        )));
+
+        let lease = DhcpV6Lease::new_from_msg(&msg).unwrap();
+        assert_eq!(
+            lease.domain_list,
+            vec!["example.com".to_string(), "example.org".to_string()]
+        );
+        assert_eq!(
+            lease.ntp_srvs,
+            vec![
+                "ntp.example.com".to_string(),
+                "ntp2.example.com".to_string(),
+            ]
+        );
     }
 }

--- a/src/dhcpv6/option.rs
+++ b/src/dhcpv6/option.rs
@@ -112,6 +112,13 @@ const OPTION_DOMAIN_LIST: u16 = 24;
 const OPTION_IA_PD: u16 = 25;
 const OPTION_IAPREFIX: u16 = 26;
 const OPTION_NTP_SERVER: u16 = 56;
+const DNS_LABEL_MAX_LEN: usize = 63;
+const DNS_NAME_MAX_LEN: usize = 255;
+// A 255-octet name with 1-octet labels can contain at most 127
+// labels, so 128 is the maximum possible loop count.
+const DNS_MAX_LABELS: usize = 128;
+// RFC 1035: the high two bits of a label length must be zero.
+const DNS_LABEL_LENGTH_MASK: u8 = 0xC0;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Default)]
 #[non_exhaustive]
@@ -420,16 +427,10 @@ impl DhcpV6Option {
                 let mut tmp_opt_buf = Buffer::new(raw);
                 let mut domains = Vec::new();
                 while !tmp_opt_buf.is_empty() {
-                    let str_len = tmp_opt_buf.get_u8().context(
-                        "Invalid DHCPv6 option OPTION_DOMAIN_LIST length",
-                    )?;
                     domains.push(
-                        tmp_opt_buf
-                            .get_string_with_null(str_len.into())
-                            .context(
-                                "Invalid DHCPv6 option OPTION_DOMAIN_LIST \
-                                 domain",
-                            )?,
+                        parse_domain_name(&mut tmp_opt_buf).context(
+                            "Invalid DHCPv6 option OPTION_DOMAIN_LIST",
+                        )?,
                     );
                 }
                 Self::DomainList(domains)
@@ -519,8 +520,7 @@ impl DhcpV6Option {
             Self::DomainList(domains) => {
                 let mut value_buf = BufferMut::new();
                 for domain in domains {
-                    value_buf.write_u8((domain.len() + 1) as u8);
-                    value_buf.write_string_with_null(domain, domain.len() + 1);
+                    write_domain_name(&mut value_buf, domain);
                 }
                 buf.write_u16_be(self.code().into());
                 buf.write_u16_be(value_buf.len() as u16);
@@ -542,6 +542,76 @@ impl DhcpV6Option {
             }
         }
     }
+}
+
+fn parse_domain_name(buf: &mut Buffer) -> Result<String, DhcpError> {
+    let mut labels = Vec::new();
+    let mut name_len = 1usize; // The root label.
+    let mut label_count = 0usize;
+    loop {
+        if label_count >= DNS_MAX_LABELS {
+            return Err(DhcpError::new(
+                ErrorKind::InvalidDhcpMessage,
+                format!("Domain name exceeds {DNS_MAX_LABELS} labels"),
+            ));
+        }
+        let label_len =
+            buf.get_u8().context("Invalid domain name label length")?;
+        if (label_len & DNS_LABEL_LENGTH_MASK) != 0 {
+            return Err(DhcpError::new(
+                ErrorKind::InvalidDhcpMessage,
+                format!(
+                    "Invalid domain name label length {label_len}: \
+                     compression is not supported"
+                ),
+            ));
+        }
+        if label_len == 0 {
+            break;
+        }
+        label_count += 1;
+        let label_len = usize::from(label_len);
+        name_len += 1 + label_len;
+        if name_len > DNS_NAME_MAX_LEN {
+            return Err(DhcpError::new(
+                ErrorKind::InvalidDhcpMessage,
+                format!("Domain name exceeds {DNS_NAME_MAX_LEN} octets"),
+            ));
+        }
+        let label = buf
+            .get_bytes(label_len)
+            .context("Invalid domain name label")?;
+        let label = std::str::from_utf8(label).map_err(|e| {
+            DhcpError::new(
+                ErrorKind::InvalidDhcpMessage,
+                format!("Domain name label is not valid UTF-8: {e}"),
+            )
+        })?;
+        labels.push(label.to_string());
+    }
+    Ok(labels.join("."))
+}
+
+fn write_domain_name(buf: &mut BufferMut, domain: &str) {
+    let domain = domain.strip_suffix('.').unwrap_or(domain);
+    if domain.is_empty() {
+        buf.write_u8(0);
+        return;
+    }
+    for label in domain.split('.') {
+        let label_len = label.len();
+        if label_len == 0 || label_len > DNS_LABEL_MAX_LEN {
+            log::warn!(
+                "Ignore invalid domain name in DHCPv6 option: label length \
+                 {label_len}"
+            );
+            buf.write_u8(0);
+            return;
+        }
+        buf.write_u8(label_len as u8);
+        buf.write_bytes(label.as_bytes());
+    }
+    buf.write_u8(0);
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -616,36 +686,23 @@ impl DhcpV6OptionNtpServer {
                 Self::MulticastAddr(Ipv6Addr::from(octets))
             }
             NTP_SUBOPTION_SRV_FQDN => Self::ServerFqdn({
-                let mut lables = Vec::new();
                 let raw = buf.get_bytes(subopt_len.into()).context(
                     "Invalid OPTION_NTP_SERVER NTP_SUBOPTION_SRV_FQDN",
                 )?;
                 let mut fqdn_buf = Buffer::new(raw);
-                while !fqdn_buf.is_empty() {
-                    let lable_len = fqdn_buf.get_u8().context(
-                        "Invalid OPTION_NTP_SERVER NTP_SUBOPTION_SRV_FQDN",
-                    )?;
-                    if lable_len == 0 {
-                        break;
-                    }
-                    let lable_raw =
-                        fqdn_buf.get_bytes(lable_len as usize).context(
-                            "Invalid OPTION_NTP_SERVER NTP_SUBOPTION_SRV_FQDN",
-                        )?;
-                    match std::str::from_utf8(lable_raw) {
-                        Ok(l) => lables.push(l.to_string()),
-                        Err(e) => {
-                            return Err(DhcpError::new(
-                                ErrorKind::InvalidDhcpMessage,
-                                format!(
-                                    "Invalid OPTION_NTP_SERVER \
-                                     NTP_SUBOPTION_SRV_FQDN: {e}"
-                                ),
-                            ));
-                        }
-                    }
+                let fqdn = parse_domain_name(&mut fqdn_buf).context(
+                    "Invalid OPTION_NTP_SERVER NTP_SUBOPTION_SRV_FQDN",
+                )?;
+                if !fqdn_buf.is_empty() {
+                    return Err(DhcpError::new(
+                        ErrorKind::InvalidDhcpMessage,
+                        format!(
+                            "Invalid NTP SRV_FQDN subopt_len {subopt_len}, \
+                             trailing data after domain name"
+                        ),
+                    ));
                 }
-                lables.join(".").to_string()
+                fqdn
             }),
             _ => Self::Other((
                 subopt_type,
@@ -672,9 +729,11 @@ impl DhcpV6OptionNtpServer {
                 buf.write_ipv6(*ip);
             }
             Self::ServerFqdn(name) => {
+                let mut value_buf = BufferMut::new();
+                write_domain_name(&mut value_buf, name);
                 buf.write_u16_be(NTP_SUBOPTION_SRV_FQDN);
-                buf.write_u16_be((name.len() + 1) as u16);
-                buf.write_string_with_null(name, name.len() + 1);
+                buf.write_u16_be(value_buf.len() as u16);
+                buf.write_bytes(value_buf.data.as_slice());
             }
             Self::Other((subopt_type, v)) => {
                 buf.write_u16_be(*subopt_type);
@@ -793,6 +852,144 @@ mod test {
             DhcpV6OptionNtpServer::ServerAddr(Ipv6Addr::new(
                 0x2001, 0x0DB8, 0, 0, 0, 0, 0, 1
             ))
+        );
+    }
+
+    #[test]
+    fn domain_list_parses_rfc1035_labels() {
+        // OPTION_DOMAIN_LIST with "www.example.com" and "ntp.example.org"
+        // encoded as RFC 1035 labels.
+        let raw: Vec<u8> = vec![
+            0x00, 0x18, // OPTION_DOMAIN_LIST
+            0x00, 0x22, // option-len = 34
+            0x03, b'w', b'w', b'w', 0x07, b'e', b'x', b'a', b'm', b'p', b'l',
+            b'e', 0x03, b'c', b'o', b'm', 0x00, 0x03, b'n', b't', b'p', 0x07,
+            b'e', b'x', b'a', b'm', b'p', b'l', b'e', 0x03, b'o', b'r', b'g',
+            0x00,
+        ];
+        let mut buf = Buffer::new(&raw);
+        let opt = DhcpV6Option::parse(&mut buf).expect("valid domain list");
+        assert_eq!(
+            opt,
+            DhcpV6Option::DomainList(vec![
+                "www.example.com".to_string(),
+                "ntp.example.org".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn domain_list_emit_uses_rfc1035_labels() {
+        let opt = DhcpV6Option::DomainList(vec![
+            "www.example.com".to_string(),
+            "ntp.example.org".to_string(),
+        ]);
+        let mut buf = BufferMut::new();
+        opt.emit(&mut buf);
+        let expected: Vec<u8> = vec![
+            0x00, 0x18, // OPTION_DOMAIN_LIST
+            0x00, 0x22, // option-len = 34
+            0x03, b'w', b'w', b'w', 0x07, b'e', b'x', b'a', b'm', b'p', b'l',
+            b'e', 0x03, b'c', b'o', b'm', 0x00, 0x03, b'n', b't', b'p', 0x07,
+            b'e', b'x', b'a', b'm', b'p', b'l', b'e', 0x03, b'o', b'r', b'g',
+            0x00,
+        ];
+        assert_eq!(buf.data, expected);
+    }
+
+    #[test]
+    fn domain_list_accepts_maximum_rfc1035_labels() {
+        // 127 single-character labels is the maximum allowed by
+        // RFC 1035's 255-octet name limit.
+        let mut value = Vec::new();
+        for _ in 0..127 {
+            value.push(1);
+            value.push(b'a');
+        }
+        value.push(0);
+
+        let mut raw = vec![0x00, 0x18]; // OPTION_DOMAIN_LIST
+        raw.extend_from_slice(&(value.len() as u16).to_be_bytes());
+        raw.extend(value);
+
+        let mut buf = Buffer::new(&raw);
+        let opt = DhcpV6Option::parse(&mut buf).expect("maximum labels");
+        assert_eq!(
+            opt,
+            DhcpV6Option::DomainList(
+                vec![vec!["a".to_string(); 127].join(".")]
+            )
+        );
+    }
+
+    #[test]
+    fn ntp_server_fqdn_parses_rfc1035_labels() {
+        // OPTION_NTP_SERVER with SRV_FQDN suboption carrying
+        // "ntp.example.com" encoded as RFC 1035 labels.
+        let raw: Vec<u8> = vec![
+            0x00, 0x38, // OPTION_NTP_SERVER
+            0x00, 0x15, // option-len = 21
+            0x00, 0x03, // SRV_FQDN
+            0x00, 0x11, // subopt-len = 17
+            0x03, b'n', b't', b'p', 0x07, b'e', b'x', b'a', b'm', b'p', b'l',
+            b'e', 0x03, b'c', b'o', b'm', 0x00,
+        ];
+        let mut buf = Buffer::new(&raw);
+        let opt = DhcpV6Option::parse(&mut buf).expect("valid NTP server");
+        assert_eq!(
+            opt,
+            DhcpV6Option::NtpServer(vec![DhcpV6OptionNtpServer::ServerFqdn(
+                "ntp.example.com".to_string()
+            )])
+        );
+    }
+
+    #[test]
+    fn ntp_server_fqdn_emit_uses_rfc1035_labels() {
+        let opt =
+            DhcpV6Option::NtpServer(vec![DhcpV6OptionNtpServer::ServerFqdn(
+                "ntp.example.com".to_string(),
+            )]);
+        let mut buf = BufferMut::new();
+        opt.emit(&mut buf);
+        let expected: Vec<u8> = vec![
+            0x00, 0x38, // OPTION_NTP_SERVER
+            0x00, 0x15, // option-len = 21
+            0x00, 0x03, // SRV_FQDN
+            0x00, 0x11, // subopt-len = 17
+            0x03, b'n', b't', b'p', 0x07, b'e', b'x', b'a', b'm', b'p', b'l',
+            b'e', 0x03, b'c', b'o', b'm', 0x00,
+        ];
+        assert_eq!(buf.data, expected);
+    }
+
+    #[test]
+    fn ntp_server_fqdn_emit_parse_round_trip() {
+        let opt =
+            DhcpV6Option::NtpServer(vec![DhcpV6OptionNtpServer::ServerFqdn(
+                "ntp.example.com".to_string(),
+            )]);
+        let mut buf = BufferMut::new();
+        opt.emit(&mut buf);
+        let mut buf = Buffer::new(&buf.data);
+        let parsed = DhcpV6Option::parse(&mut buf).expect("round-trip parse");
+        assert_eq!(parsed, opt);
+    }
+
+    #[test]
+    fn ntp_server_fqdn_trailing_bytes_rejected() {
+        // subopt-len is 18, but the FQDN is only 17 bytes, leaving one
+        // byte after the root label.
+        let raw: Vec<u8> = vec![
+            0x00, 0x03, // SRV_FQDN
+            0x00, 0x12, // subopt-len = 18
+            0x03, b'n', b't', b'p', 0x07, b'e', b'x', b'a', b'm', b'p', b'l',
+            b'e', 0x03, b'c', b'o', b'm', 0x00, 0x01, // trailing byte
+        ];
+        let mut buf = Buffer::new(&raw);
+        assert!(
+            DhcpV6OptionNtpServer::parse(&mut buf).is_err(),
+            "expected Err for NTP SRV_FQDN with trailing data"
         );
     }
 }

--- a/src/integ_tests/dhcpv6.rs
+++ b/src/integ_tests/dhcpv6.rs
@@ -20,6 +20,17 @@ fn test_dhcpv6() {
             // call to use_host_name_as_client_id(), then the server should
             // return FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID.
             assert_eq!(lease.address, FOO1_STATIC_IPV6);
+            assert_eq!(
+                lease.domain_list,
+                vec!["example.com".to_string(), "example.org".to_string()]
+            );
+            assert_eq!(
+                lease.ntp_srvs,
+                vec![
+                    "ntp.example.com".to_string(),
+                    "ntp2.example.com".to_string(),
+                ]
+            );
         }
     })
 }

--- a/src/integ_tests/env.rs
+++ b/src/integ_tests/env.rs
@@ -94,6 +94,8 @@ fn start_dhcp_server() {
         --dhcp-option=option:mtu,1492
         --dhcp-option=option:domain-name,example.com
         --dhcp-option=option:ntp-server,192.0.2.1
+        --dhcp-option=option6:domain-search,example.com,example.org
+        --dhcp-option=option6:ntp-server,ntp.example.com,ntp2.example.com
         --dhcp-option=121,{TEST_CLS_DST}/{TEST_CLS_DST_LEN},{TEST_CLS_RT_ADDR}
         --dhcp-option=249,{TEST_CLS_DST}/{TEST_CLS_DST_LEN},{TEST_CLS_RT_ADDR}
         --bind-interfaces


### PR DESCRIPTION
`DhcpV6Lease` now provides `domain_list` and `ntp_srvs` populated
from OPTION_DOMAIN_LIST and OPTION_NTP_SERVER, including RFC 1035
label-encoded FQDNs.

Integration test uses dnsmasq to verify multiple search domains
and multiple NTP FQDN values. Unit tests included.