### PR TITLE
dhcpv4: fix add_jitter() jitter range

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,22 +1,20 @@
-1. `add_jitter()` doc says -2..+2s but the code yields
-   -2..+1.
-2. Explicit T1/T2 option values of 0 pass `validate()` and
-   produce an immediate-renew loop; only ordering is checked.
-3. `new_request()` (`src/dhcpv4/msg.rs`) inserts
-   `ServerIdentifier` twice: first unconditionally, then again in
-   the `srv_id != UNSPECIFIED` branch. Harmless on the wire
-   (`DhcpV4Options::insert()` is a `HashMap` insert keyed by option
-   code, second overwrites first), but the unconditional insert is
-   dead code.
-4. Lacking integration test without `netlink` feature. The
-   4 netns integ tests create clients by interface name only and
-   `unwrap()` on `init()`, which needs `resolve()`; built with
-   `--no-default-features` they all fail. CI only runs
-   `cargo build --no-default-features` (never tests), so the gap is
-   invisible. Options: gate those tests on `feature = "netlink"`,
-   or add an integ test using manual `set_iface_index()` +
-   `set_iface_mac_raw()` to cover the no-netlink path.
-5. DHCPv6 domain names reject RFC 1035 compressed/pointer-style
-   labels (RFC 1035 section 4.1.4); parsing returns
-   `InvalidDhcpMessage` when the high two bits of a label length
-   are set.
+- Explicit T1/T2 option values of 0 pass `validate()` and
+  produce an immediate-renew loop; only ordering is checked.
+- `new_request()` (`src/dhcpv4/msg.rs`) inserts
+  `ServerIdentifier` twice: first unconditionally, then again in
+  the `srv_id != UNSPECIFIED` branch. Harmless on the wire
+  (`DhcpV4Options::insert()` is a `HashMap` insert keyed by option
+  code, second overwrites first), but the unconditional insert is
+  dead code.
+- Lacking integration test without `netlink` feature. The
+  4 netns integ tests create clients by interface name only and
+  `unwrap()` on `init()`, which needs `resolve()`; built with
+  `--no-default-features` they all fail. CI only runs
+  `cargo build --no-default-features` (never tests), so the gap is
+  invisible. Options: gate those tests on `feature = "netlink"`,
+  or add an integ test using manual `set_iface_index()` +
+  `set_iface_mac_raw()` to cover the no-netlink path.
+- DHCPv6 domain names reject RFC 1035 compressed/pointer-style
+  labels (RFC 1035 section 4.1.4); parsing returns
+  `InvalidDhcpMessage` when the high two bits of a label length
+  are set.

--- a/src/dhcpv4/lease.rs
+++ b/src/dhcpv4/lease.rs
@@ -213,7 +213,7 @@ fn add_jitter(val: u32) -> u32 {
     if val < 20 {
         return val;
     }
-    val + rand::random_range(0..4) - 2
+    val + rand::random_range(0..5) - 2
 }
 
 #[cfg(test)]
@@ -372,5 +372,25 @@ mod test {
             .lease()
             .unwrap();
         assert_eq!(lease.srv_mac, srv_mac);
+    }
+
+    #[test]
+    fn test_add_jitter_range() {
+        let val = 1000;
+        let mut min_jitter = i32::MAX;
+        let mut max_jitter = i32::MIN;
+        for _ in 0..1000 {
+            let jitter = add_jitter(val) as i32 - val as i32;
+            min_jitter = min_jitter.min(jitter);
+            max_jitter = max_jitter.max(jitter);
+        }
+        assert_eq!((min_jitter, max_jitter), (-2, 2));
+    }
+
+    #[test]
+    fn test_add_jitter_below_threshold_unchanged() {
+        for val in [0, 1, 19] {
+            assert_eq!(add_jitter(val), val);
+        }
     }
 }


### PR DESCRIPTION
The random jitter only produced -2..+1 instead of the documented
-2..+2 because random_range() upper bound is exclusive.

Fixed by using an inclusive upper bound; unit tests added.