### PR TITLE
dhcpv4/dhcpv6: validate manual leases before installing timers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,3 @@
-- `DhcpV4Client::done()` does not validate manually constructed
-  leases: `set_lease_timer()` (`src/dhcpv4/time.rs`) creates
-  zero-duration timers when T1/T2 are 0, reproducing the
-  immediate-renew loop for leases not parsed via
-  `DhcpV4Lease::new_from_msg()`.
 - `new_request()` (`src/dhcpv4/msg.rs`) inserts
   `ServerIdentifier` twice: first unconditionally, then again in
   the `srv_id != UNSPECIFIED` branch. Harmless on the wire

--- a/src/dhcpv4/client.rs
+++ b/src/dhcpv4/client.rs
@@ -185,6 +185,7 @@ impl DhcpV4Client {
     }
 
     pub fn done(&mut self, lease: DhcpV4Lease) -> Result<(), DhcpError> {
+        lease.validate()?;
         self.set_lease_timer(&lease)?;
         self.timeout_timer = None;
         self.raw_socket = None;
@@ -280,5 +281,82 @@ mod test {
         assert!(cli.timeout_timer.is_some());
         cli.clean_up();
         assert!(cli.timeout_timer.is_none());
+    }
+
+    #[test]
+    fn test_done_rejects_zero_t1() {
+        let mut lease = DhcpV4Lease::default();
+        lease.t2_sec = 60;
+        lease.lease_time_sec = 100;
+        let mut cli = DhcpV4Client::default();
+        let err = cli.done(lease).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("T1"),
+            "unexpected error message: {}",
+            err.msg()
+        );
+    }
+
+    #[test]
+    fn test_done_rejects_zero_t2() {
+        let mut lease = DhcpV4Lease::default();
+        lease.t1_sec = 30;
+        lease.lease_time_sec = 100;
+        let mut cli = DhcpV4Client::default();
+        let err = cli.done(lease).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("T2"),
+            "unexpected error message: {}",
+            err.msg()
+        );
+    }
+
+    #[test]
+    fn test_done_rejects_t1_not_earlier_than_t2() {
+        let mut lease = DhcpV4Lease::default();
+        lease.t1_sec = 60;
+        lease.t2_sec = 60;
+        lease.lease_time_sec = 100;
+        let mut cli = DhcpV4Client::default();
+        let err = cli.done(lease).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("T1"),
+            "unexpected error message: {}",
+            err.msg()
+        );
+    }
+
+    #[test]
+    fn test_done_rejects_t2_not_earlier_than_lease_time() {
+        let mut lease = DhcpV4Lease::default();
+        lease.t1_sec = 30;
+        lease.t2_sec = 100;
+        lease.lease_time_sec = 100;
+        let mut cli = DhcpV4Client::default();
+        let err = cli.done(lease).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("T2"),
+            "unexpected error message: {}",
+            err.msg()
+        );
+    }
+
+    #[test]
+    fn test_done_accepts_valid_manual_lease() {
+        let mut lease = DhcpV4Lease::default();
+        lease.t1_sec = 30;
+        lease.t2_sec = 60;
+        lease.lease_time_sec = 100;
+        let mut cli = DhcpV4Client::default();
+        cli.done(lease).unwrap();
+        assert!(cli.t1_timer.is_some());
+        assert!(cli.t2_timer.is_some());
+        assert!(cli.lease_timer.is_some());
+        assert!(cli.lease.is_some());
+        assert!(matches!(cli.state, DhcpV4State::Done(_)));
     }
 }

--- a/src/dhcpv4/lease.rs
+++ b/src/dhcpv4/lease.rs
@@ -188,7 +188,7 @@ impl DhcpV4Lease {
         Ok(ret)
     }
 
-    fn validate(&self) -> Result<(), DhcpError> {
+    pub(crate) fn validate(&self) -> Result<(), DhcpError> {
         // RFC 2131 4.4.5: T1 MUST be earlier than T2, which, in turn,
         // MUST be earlier than the time at which the lease expires.
         if self.t1_sec == 0 {

--- a/src/dhcpv6/client.rs
+++ b/src/dhcpv6/client.rs
@@ -209,6 +209,8 @@ impl DhcpV6Client {
     }
 
     pub fn done(&mut self, lease: DhcpV6Lease) -> Result<(), DhcpError> {
+        let mut lease = lease;
+        lease.sanitize_lease()?;
         self.set_lease_timer(&lease)?;
         self.reset_retransmit_counters();
         self.timeout_timer = None;
@@ -274,6 +276,14 @@ mod test {
         DhcpV6Client::init(config, None).await.unwrap()
     }
 
+    fn manual_lease() -> DhcpV6Lease {
+        let mut lease = DhcpV6Lease::default();
+        lease.address = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        lease.preferred_time_sec = 120;
+        lease.valid_time_sec = 240;
+        lease
+    }
+
     #[tokio::test]
     async fn test_timeout_timer_spans_run_calls() {
         let mut cli = test_client().await;
@@ -294,5 +304,53 @@ mod test {
         assert!(cli.timeout_timer.is_some());
         cli.clean_up();
         assert!(cli.timeout_timer.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_done_defaults_zero_t1_t2() {
+        let mut cli = test_client().await;
+        cli.done(manual_lease()).unwrap();
+        let lease = cli.lease.as_ref().unwrap();
+        assert_eq!(lease.t1_sec, 60);
+        assert_eq!(lease.t2_sec, 90);
+        assert!(cli.t1_timer.is_some());
+        assert!(cli.t2_timer.is_some());
+        assert!(cli.valid_timer.is_some());
+        assert!(matches!(cli.state, DhcpV6State::Done(_)));
+    }
+
+    #[tokio::test]
+    async fn test_done_rejects_invalid_manual_lease() {
+        let mut lease = manual_lease();
+        lease.t1_sec = 200;
+        lease.t2_sec = 100;
+        let mut cli = test_client().await;
+        let err = cli.done(lease).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("T1"),
+            "unexpected error message: {}",
+            err.msg()
+        );
+        assert!(cli.t1_timer.is_none());
+        assert!(cli.t2_timer.is_none());
+        assert!(cli.valid_timer.is_none());
+        assert_eq!(cli.state, DhcpV6State::Solicit);
+    }
+
+    #[tokio::test]
+    async fn test_done_rejects_zero_timers_without_preferred_lifetime() {
+        let mut lease = manual_lease();
+        lease.preferred_time_sec = 0;
+        let mut cli = test_client().await;
+        let err = cli.done(lease).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("T1"),
+            "unexpected error message: {}",
+            err.msg()
+        );
+        assert!(cli.t1_timer.is_none());
+        assert!(cli.t2_timer.is_none());
     }
 }

--- a/src/dhcpv6/lease.rs
+++ b/src/dhcpv6/lease.rs
@@ -99,16 +99,6 @@ impl DhcpV6Lease {
                     ret.iaid = v.iaid;
                     ret.t1_sec = v.t1_sec;
                     ret.t2_sec = v.t2_sec;
-                    // RFC 8415 14.2. Client Behavior when T1 and/or T2 Are 0
-                    // This is an indication that the renew and rebind times are
-                    // left to the discretion of the client.
-                    if ret.t1_sec == 0 && ret.preferred_time_sec != 0 {
-                        ret.t1_sec = ret.preferred_time_sec / 2;
-                    }
-                    if ret.t2_sec == 0 && ret.preferred_time_sec != 0 {
-                        ret.t2_sec = ret.preferred_time_sec / 2
-                            + ret.preferred_time_sec / 4;
-                    }
                 }
             } else if let Some(status) = v.status.as_ref() {
                 log::info!(
@@ -172,16 +162,6 @@ impl DhcpV6Lease {
                     ret.iaid = v.iaid;
                     ret.t1_sec = v.t1_sec;
                     ret.t2_sec = v.t2_sec;
-                    // RFC 8415 14.2. Client Behavior when T1 and/or T2 Are 0
-                    // This is an indication that the renew and rebind times are
-                    // left to the discretion of the client.
-                    if ret.t1_sec == 0 && ret.preferred_time_sec != 0 {
-                        ret.t1_sec = ret.preferred_time_sec / 2;
-                    }
-                    if ret.t2_sec == 0 && ret.preferred_time_sec != 0 {
-                        ret.t2_sec = ret.preferred_time_sec / 2
-                            + ret.preferred_time_sec / 4;
-                    }
                 }
             } else if let Some(status) = v.status.as_ref() {
                 log::info!(
@@ -248,7 +228,30 @@ impl DhcpV6Lease {
         Ok(ret)
     }
 
-    fn sanitize_lease(&self) -> Result<(), DhcpError> {
+    pub(crate) fn sanitize_lease(&mut self) -> Result<(), DhcpError> {
+        // RFC 8415 14.2. Client Behavior when T1 and/or T2 Are 0.
+        // Zero means the renew and rebind times are left to the
+        // discretion of the client, so pick a non-zero default to
+        // avoid renewing immediately.
+        if self.t1_sec == 0 && self.preferred_time_sec != 0 {
+            self.t1_sec = self.preferred_time_sec / 2;
+        }
+        if self.t2_sec == 0 && self.preferred_time_sec != 0 {
+            self.t2_sec =
+                self.preferred_time_sec / 2 + self.preferred_time_sec / 4;
+        }
+        if self.t1_sec == 0 {
+            return Err(DhcpError::new(
+                ErrorKind::InvalidDhcpMessage,
+                "DHCPv6 lease contains zero T1".to_string(),
+            ));
+        }
+        if self.t2_sec == 0 {
+            return Err(DhcpError::new(
+                ErrorKind::InvalidDhcpMessage,
+                "DHCPv6 lease contains zero T2".to_string(),
+            ));
+        }
         if self.t1_sec > self.t2_sec {
             return Err(DhcpError::new(
                 ErrorKind::InvalidDhcpMessage,


### PR DESCRIPTION
`DhcpV4Client::done()` accepted manually constructed leases
without RFC 2131 validation, so zero T1/T2 created
zero-duration timers and an immediate renew loop.

`DhcpV6Client::done()` had the same gap; it now sanitizes
the lease, applying the RFC 8415 zero T1/T2 defaults and
rejecting leases with no derivable timers.

Unit tests included.