### PR TITLE
dhcpv6: validate identifiers in Advertise/Reply

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,44 @@
+- DHCPv6 client accepts Advertise/Reply without checking a Server
+  Identifier is present or that Client Identifier matches the
+  client's own DUID (RFC 8415 section 16.3, 16.10).
+  `recv_dhcp_lease()` (`src/dhcpv6/socket.rs`) only checks xid and
+  message type; `DhcpV6Lease::new_from_msg()`
+  (`src/dhcpv6/lease.rs`) copies whatever `ClientId`/`ServerId`
+  option is present without comparing it to `self.config.duid`.
+  A host that observes the multicast Solicit/Request (or guesses
+  the 24-bit xid) can inject a forged reply.
+- DHCPv6 IA_PD delegated prefix length is never validated.
+  `DhcpV6OptionIaPrefix::parse()` (`src/dhcpv6/option_ia.rs`)
+  reads `prefix_len` as a raw wire `u8` (0-255) and
+  `DhcpV6Lease::sanitize_lease()` (`src/dhcpv6/lease.rs`) checks
+  T1/T2/lifetimes/address/srv_duid but never rejects
+  `prefix_len > 128`, an impossible IPv6 prefix.
+- DHCPv4 client never recognizes DHCPNAK. `recv_dhcp_lease()`
+  (`src/dhcpv4/socket.rs`) only compares the reply against one
+  `expected` message type, so a NACK during Request/Renew/Rebind
+  is dropped like any other mismatched packet instead of
+  restarting configuration immediately, as RFC 2131 section 4.4.5
+  requires.
+- DHCPv6 retransmission backoff collapses due to integer
+  truncation. `gen_retransmit_time()` (`src/dhcpv6/time.rs`)
+  computes `duration.as_millis() / 1000` before multiplying by
+  the jitter factor; whenever the running timeout is under
+  1000ms (common for Solicit/Request, whose base is 1s +/-10%),
+  the result truncates to exactly 0 and the backoff resets to the
+  baseline instead of doubling (RFC 8415 section 15). Simulating
+  the exact algorithm: 200/200 runs hit a zero-collapse, and only
+  ~49% of Solicit runs and ~66% of Request runs approached their
+  max backoff (3600s/30s) within their retry budget. Renew/Rebind
+  (10s base) are unaffected.
+- DHCPv4 client does not support Option Overload (option 52).
+  `DhcpV4Message::parse()` (`src/dhcpv4/msg.rs`) only parses the
+  fixed options area; options a server places in `sname`/`file`
+  per RFC 2131 section 3 / RFC 2132 section 9.3 are invisible to
+  the parser.
+- DHCPv4 repeated options overwrite instead of concatenating.
+  `DhcpV4Options::insert()` (`src/dhcpv4/option.rs`) stores one
+  value per code in a `HashMap`, so a second TLV instance with
+  the same code replaces the first instead of being concatenated
+  per RFC 3396. Affects any option value long enough to need
+  splitting across multiple 255-byte options (e.g. many
+  classless routes).

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,3 @@
-- DHCPv6 client accepts Advertise/Reply without checking a Server
-  Identifier is present or that Client Identifier matches the
-  client's own DUID (RFC 8415 section 16.3, 16.10).
-  `recv_dhcp_lease()` (`src/dhcpv6/socket.rs`) only checks xid and
-  message type; `DhcpV6Lease::new_from_msg()`
-  (`src/dhcpv6/lease.rs`) copies whatever `ClientId`/`ServerId`
-  option is present without comparing it to `self.config.duid`.
-  A host that observes the multicast Solicit/Request (or guesses
-  the 24-bit xid) can inject a forged reply.
 - DHCPv6 IA_PD delegated prefix length is never validated.
   `DhcpV6OptionIaPrefix::parse()` (`src/dhcpv6/option_ia.rs`)
   reads `prefix_len` as a raw wire `u8` (0-255) and

--- a/src/dhcpv6/lease.rs
+++ b/src/dhcpv6/lease.rs
@@ -68,21 +68,41 @@ impl DhcpV6Lease {
         self.dhcp_opts.get_data_raw(code)
     }
 
-    pub(crate) fn new_from_msg(msg: &DhcpV6Message) -> Result<Self, DhcpError> {
+    pub(crate) fn new_from_msg(
+        msg: &DhcpV6Message,
+        expected_cli_duid: &DhcpV6Duid,
+    ) -> Result<Self, DhcpError> {
         let mut ret = Self {
             xid: msg.xid(),
             dhcp_opts: msg.options.clone(),
             ..Default::default()
         };
-        if let Some(DhcpV6Option::ClientId(v)) =
-            msg.options.get_first(DhcpV6OptionCode::ClientId)
-        {
-            ret.cli_duid = v.clone();
-        }
+        // RFC 8415 sections 16.3 and 16.10: a client must discard an
+        // Advertise/Reply that lacks a Server Identifier, lacks a Client
+        // Identifier, or carries a Client Identifier that does not match the
+        // client's DUID.
         if let Some(DhcpV6Option::ServerId(v)) =
             msg.options.get_first(DhcpV6OptionCode::ServerId)
         {
             ret.srv_duid = v.clone();
+        } else {
+            return Err(DhcpError::new(
+                ErrorKind::InvalidDhcpMessage,
+                "DHCPv6 reply contains no Server Identifier".to_string(),
+            ));
+        }
+        match msg.options.get_first(DhcpV6OptionCode::ClientId) {
+            Some(DhcpV6Option::ClientId(v)) if v == expected_cli_duid => {
+                ret.cli_duid = v.clone();
+            }
+            _ => {
+                return Err(DhcpError::new(
+                    ErrorKind::InvalidDhcpMessage,
+                    "DHCPv6 reply Client Identifier missing or not matching \
+                     this client's DUID"
+                        .to_string(),
+                ));
+            }
         }
         if let Some(DhcpV6Option::IANA(v)) =
             msg.options.get_first(DhcpV6OptionCode::IANA)
@@ -313,12 +333,13 @@ mod test {
 
     #[test]
     fn lease_reads_ntp_fqdn_and_domain_list() {
+        let client_duid = DhcpV6Duid::Raw(vec![1]);
         let mut msg = DhcpV6Message {
             msg_type: DhcpV6MessageType::Advertise,
             ..Default::default()
         };
         msg.options
-            .insert(DhcpV6Option::ClientId(DhcpV6Duid::Raw(vec![1])));
+            .insert(DhcpV6Option::ClientId(client_duid.clone()));
         msg.options
             .insert(DhcpV6Option::ServerId(DhcpV6Duid::Raw(vec![2])));
         msg.options.insert(DhcpV6Option::DomainList(vec![
@@ -340,7 +361,8 @@ mod test {
             ),
         )));
 
-        let lease = DhcpV6Lease::new_from_msg(&msg).unwrap();
+        let lease = DhcpV6Lease::new_from_msg(&msg, &client_duid).unwrap();
+        assert_eq!(lease.cli_duid, client_duid);
         assert_eq!(
             lease.domain_list,
             vec!["example.com".to_string(), "example.org".to_string()]
@@ -351,6 +373,89 @@ mod test {
                 "ntp.example.com".to_string(),
                 "ntp2.example.com".to_string(),
             ]
+        );
+    }
+
+    fn valid_reply_msg(client_duid: &DhcpV6Duid) -> DhcpV6Message {
+        let mut msg = DhcpV6Message {
+            msg_type: DhcpV6MessageType::Reply,
+            ..Default::default()
+        };
+        msg.options
+            .insert(DhcpV6Option::ClientId(client_duid.clone()));
+        msg.options
+            .insert(DhcpV6Option::ServerId(DhcpV6Duid::Raw(vec![2])));
+        msg.options.insert(DhcpV6Option::IANA(DhcpV6OptionIaNa::new(
+            1,
+            60,
+            90,
+            DhcpV6OptionIaAddr::new(
+                Ipv6Addr::new(0x2001, 0x0db8, 0x000a, 0, 0, 0, 0, 0x99),
+                120,
+                240,
+            ),
+        )));
+        msg
+    }
+
+    #[test]
+    fn new_from_msg_accepts_matching_reply_identifiers() {
+        let client_duid = DhcpV6Duid::Raw(vec![1]);
+        let msg = valid_reply_msg(&client_duid);
+
+        let lease = DhcpV6Lease::new_from_msg(&msg, &client_duid).unwrap();
+
+        assert_eq!(lease.cli_duid, client_duid);
+        assert_eq!(lease.srv_duid, DhcpV6Duid::Raw(vec![2]));
+    }
+
+    #[test]
+    fn new_from_msg_rejects_reply_without_server_identifier() {
+        let client_duid = DhcpV6Duid::Raw(vec![1]);
+        let mut msg = valid_reply_msg(&client_duid);
+        msg.options.remove(DhcpV6OptionCode::ServerId);
+
+        let err = DhcpV6Lease::new_from_msg(&msg, &client_duid).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("Server Identifier"),
+            "unexpected error message: {}",
+            err.msg()
+        );
+    }
+
+    #[test]
+    fn new_from_msg_rejects_reply_without_client_identifier() {
+        let client_duid = DhcpV6Duid::Raw(vec![1]);
+        let mut msg = valid_reply_msg(&client_duid);
+        msg.options.remove(DhcpV6OptionCode::ClientId);
+
+        let err = DhcpV6Lease::new_from_msg(&msg, &client_duid).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("Client Identifier"),
+            "unexpected error message: {}",
+            err.msg()
+        );
+    }
+
+    #[test]
+    fn new_from_msg_rejects_mismatched_client_identifier() {
+        let client_duid = DhcpV6Duid::Raw(vec![1]);
+        let mut msg = valid_reply_msg(&client_duid);
+        msg.options.remove(DhcpV6OptionCode::ClientId);
+        msg.options
+            .insert(DhcpV6Option::ClientId(DhcpV6Duid::Raw(vec![2])));
+
+        let err = DhcpV6Lease::new_from_msg(&msg, &client_duid).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("Client Identifier"),
+            "unexpected error message: {}",
+            err.msg()
         );
     }
 }

--- a/src/dhcpv6/rebind.rs
+++ b/src/dhcpv6/rebind.rs
@@ -110,6 +110,7 @@ impl DhcpV6Client {
             lease,
         );
         let xid = self.xid;
+        let client_duid = self.config.duid.clone();
 
         let udp_socket = self.get_udp_socket_or_init().await?;
 
@@ -122,7 +123,7 @@ impl DhcpV6Client {
         // failing on first DHCP invalid reply
         loop {
             match udp_socket
-                .recv_dhcp_lease(DhcpV6MessageType::Reply, xid)
+                .recv_dhcp_lease(DhcpV6MessageType::Reply, xid, &client_duid)
                 .await
             {
                 Ok(Some(l)) => {

--- a/src/dhcpv6/renew.rs
+++ b/src/dhcpv6/renew.rs
@@ -107,6 +107,7 @@ impl DhcpV6Client {
             lease,
         );
         let xid = self.xid;
+        let client_duid = self.config.duid.clone();
 
         let udp_socket = self.get_udp_socket_or_init().await?;
 
@@ -123,7 +124,7 @@ impl DhcpV6Client {
         // failing on first DHCP invalid reply
         loop {
             match udp_socket
-                .recv_dhcp_lease(DhcpV6MessageType::Reply, xid)
+                .recv_dhcp_lease(DhcpV6MessageType::Reply, xid, &client_duid)
                 .await
             {
                 Ok(Some(l)) => {

--- a/src/dhcpv6/request.rs
+++ b/src/dhcpv6/request.rs
@@ -89,6 +89,7 @@ impl DhcpV6Client {
             &self.trans_begin_time,
             pending_lease,
         );
+        let client_duid = self.config.duid.clone();
         let udp_socket = self.get_udp_socket_or_init().await?;
 
         log::debug!("Sending Request");
@@ -104,7 +105,7 @@ impl DhcpV6Client {
         // failing on first DHCP invalid reply
         loop {
             match udp_socket
-                .recv_dhcp_lease(DhcpV6MessageType::Reply, xid)
+                .recv_dhcp_lease(DhcpV6MessageType::Reply, xid, &client_duid)
                 .await
             {
                 Ok(Some(l)) => {

--- a/src/dhcpv6/socket.rs
+++ b/src/dhcpv6/socket.rs
@@ -5,7 +5,7 @@ use std::net::{Ipv6Addr, SocketAddrV6};
 use tokio::net::UdpSocket;
 
 use super::msg::{DhcpV6Message, DhcpV6MessageType};
-use crate::{DhcpError, DhcpV6Lease};
+use crate::{DhcpError, DhcpV6Duid, DhcpV6Lease};
 
 /// RFC 8415: All_DHCP_Relay_Agents_and_Servers
 const ALL_DHCP_RELAY_AGENTS_AND_SERVERS: Ipv6Addr =
@@ -85,6 +85,7 @@ impl DhcpUdpV6Socket {
         &self,
         expected: DhcpV6MessageType,
         xid: u32,
+        client_duid: &DhcpV6Duid,
     ) -> Result<Option<DhcpV6Lease>, DhcpError> {
         let buffer: Vec<u8> = self.recv().await?;
         let reply_dhcp_msg = DhcpV6Message::parse(&buffer)?;
@@ -107,7 +108,7 @@ impl DhcpUdpV6Socket {
             );
             return Ok(None);
         }
-        match DhcpV6Lease::new_from_msg(&reply_dhcp_msg) {
+        match DhcpV6Lease::new_from_msg(&reply_dhcp_msg, client_duid) {
             Ok(lease) => Ok(Some(lease)),
             Err(e) => {
                 log::debug!(

--- a/src/dhcpv6/solicit.rs
+++ b/src/dhcpv6/solicit.rs
@@ -92,6 +92,7 @@ impl DhcpV6Client {
         let dhcp_packet =
             new_solicit_msg(self.xid, &self.config, &self.trans_begin_time);
         let xid = self.xid;
+        let client_duid = self.config.duid.clone();
         let udp_socket = self.get_udp_socket_or_init().await?;
 
         log::debug!("Sending Solicit");
@@ -106,7 +107,11 @@ impl DhcpV6Client {
             // `OPTION_RAPID_COMMIT`. Since we never set so, it is OK to assume
             // server only reply with Advertise.
             match udp_socket
-                .recv_dhcp_lease(DhcpV6MessageType::Advertise, xid)
+                .recv_dhcp_lease(
+                    DhcpV6MessageType::Advertise,
+                    xid,
+                    &client_duid,
+                )
                 .await
             {
                 Ok(Some(l)) => {


### PR DESCRIPTION
The DHCPv6 client accepted Advertise and Reply messages without checking
that a Server Identifier was present or that the Client Identifier matched
its own DUID, so a forged reply could install a lease.

Now pass the client DUID into lease construction and discard messages with
missing or mismatched identifiers as required by RFC 8415 sections 16.3 and
16.10.

Unit tests included.