### PR TITLE
dhcpv6: expose DNS servers in lease

### DIFF
--- a/src/dhcpv6/lease.rs
+++ b/src/dhcpv6/lease.rs
@@ -34,6 +34,9 @@ pub struct DhcpV6Lease {
     pub ntp_srvs: Vec<String>,
     /// Domain search list from OPTION_DOMAIN_LIST (RFC 3646).
     pub domain_list: Vec<String>,
+    /// DNS recursive name servers from OPTION_DNS_SERVERS (RFC 3646)
+    /// in server preference order.
+    pub dns_srvs: Vec<Ipv6Addr>,
     dhcp_opts: DhcpV6Options,
 }
 
@@ -55,6 +58,7 @@ impl Default for DhcpV6Lease {
             srv_ip: Ipv6Addr::UNSPECIFIED,
             ntp_srvs: Vec::new(),
             domain_list: Vec::new(),
+            dns_srvs: Vec::new(),
         }
     }
 }
@@ -230,6 +234,11 @@ impl DhcpV6Lease {
         {
             ret.domain_list = domains.clone();
         }
+        if let Some(DhcpV6Option::DnsServers(srvs)) =
+            msg.options.get_first(DhcpV6OptionCode::DnsServers)
+        {
+            ret.dns_srvs = srvs.clone();
+        }
         if let Some(DhcpV6Option::StatusCode(v)) =
             msg.options.get_first(DhcpV6OptionCode::StatusCode)
         {
@@ -372,6 +381,42 @@ mod test {
             vec![
                 "ntp.example.com".to_string(),
                 "ntp2.example.com".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn lease_reads_dns_servers() {
+        let client_duid = DhcpV6Duid::Raw(vec![1]);
+        let mut msg = DhcpV6Message {
+            msg_type: DhcpV6MessageType::Advertise,
+            ..Default::default()
+        };
+        msg.options
+            .insert(DhcpV6Option::ClientId(client_duid.clone()));
+        msg.options
+            .insert(DhcpV6Option::ServerId(DhcpV6Duid::Raw(vec![2])));
+        msg.options.insert(DhcpV6Option::DnsServers(vec![
+            Ipv6Addr::new(0x2001, 0x0db8, 0x000a, 0, 0, 0, 0, 0x53),
+            Ipv6Addr::new(0x2001, 0x0db8, 0x000a, 0, 0, 0, 0, 0x54),
+        ]));
+        msg.options.insert(DhcpV6Option::IANA(DhcpV6OptionIaNa::new(
+            1,
+            60,
+            90,
+            DhcpV6OptionIaAddr::new(
+                Ipv6Addr::new(0x2001, 0x0db8, 0x000a, 0, 0, 0, 0, 0x99),
+                120,
+                240,
+            ),
+        )));
+
+        let lease = DhcpV6Lease::new_from_msg(&msg, &client_duid).unwrap();
+        assert_eq!(
+            lease.dns_srvs,
+            vec![
+                Ipv6Addr::new(0x2001, 0x0db8, 0x000a, 0, 0, 0, 0, 0x53),
+                Ipv6Addr::new(0x2001, 0x0db8, 0x000a, 0, 0, 0, 0, 0x54),
             ]
         );
     }

--- a/src/integ_tests/dhcpv6.rs
+++ b/src/integ_tests/dhcpv6.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::net::Ipv6Addr;
+
 use super::env::{init_log, with_dhcp_env, FOO1_STATIC_IPV6, TEST_NIC_CLI};
 use crate::{DhcpV6Client, DhcpV6Config, DhcpV6Lease, DhcpV6Mode, DhcpV6State};
 
@@ -29,6 +31,13 @@ fn test_dhcpv6() {
                 vec![
                     "ntp.example.com".to_string(),
                     "ntp2.example.com".to_string(),
+                ]
+            );
+            assert_eq!(
+                lease.dns_srvs,
+                vec![
+                    Ipv6Addr::new(0x2001, 0xdb8, 0xa, 0, 0, 0, 0, 1),
+                    Ipv6Addr::new(0x2001, 0xdb8, 0xa, 0, 0, 0, 0, 2),
                 ]
             );
         }

--- a/src/integ_tests/env.rs
+++ b/src/integ_tests/env.rs
@@ -103,6 +103,7 @@ fn start_dhcp_server() {
         --dhcp-option=option:ntp-server,192.0.2.1
         --dhcp-option=option6:domain-search,example.com,example.org
         --dhcp-option=option6:ntp-server,ntp.example.com,ntp2.example.com
+        --dhcp-option=option6:dns-server,[2001:db8:a::1],[2001:db8:a::2]
         --dhcp-option=121,{TEST_CLS_DST}/{TEST_CLS_DST_LEN},{TEST_CLS_RT_ADDR}
         --dhcp-option=249,{TEST_CLS_DST}/{TEST_CLS_DST_LEN},{TEST_CLS_RT_ADDR}
         --bind-interfaces

--- a/src/integ_tests/no_netlink.rs
+++ b/src/integ_tests/no_netlink.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::net::Ipv6Addr;
+
 use super::env::{
     get_iface_index, get_link_local_addr, init_log, with_dhcp_env,
     FOO1_HOSTNAME, FOO1_STATIC_IPV6, FOO1_STATIC_IP_HOSTNAME_AS_CLIENT_ID,
@@ -70,6 +72,13 @@ fn test_dhcpv6_no_netlink() {
                 vec![
                     "ntp.example.com".to_string(),
                     "ntp2.example.com".to_string(),
+                ]
+            );
+            assert_eq!(
+                lease.dns_srvs,
+                vec![
+                    Ipv6Addr::new(0x2001, 0xdb8, 0xa, 0, 0, 0, 0, 1),
+                    Ipv6Addr::new(0x2001, 0xdb8, 0xa, 0, 0, 0, 0, 2),
                 ]
             );
         }


### PR DESCRIPTION
`DhcpV6Lease` now provides `dns_srvs` populated from
`OPTION_DNS_SERVERS` (RFC 3646), keeping the server preference order.
Previously the parsed option was only reachable through
`get_option_raw()`.

Unit and integration test cases included.