### PR TITLE
dhcpv6: reject delegated prefix length over 128

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
 # Changelog
+
+## [Unreleased]
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - dhcpv6: reject delegated prefix length over 128.
+
 ## [0.3.3] - 2026-08-30
 ### Breaking changes
  - N/A

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,3 @@
-- DHCPv6 IA_PD delegated prefix length is never validated.
-  `DhcpV6OptionIaPrefix::parse()` (`src/dhcpv6/option_ia.rs`)
-  reads `prefix_len` as a raw wire `u8` (0-255) and
-  `DhcpV6Lease::sanitize_lease()` (`src/dhcpv6/lease.rs`) checks
-  T1/T2/lifetimes/address/srv_duid but never rejects
-  `prefix_len > 128`, an impossible IPv6 prefix.
 - DHCPv4 client never recognizes DHCPNAK. `recv_dhcp_lease()`
   (`src/dhcpv4/socket.rs`) only compares the reply against one
   `expected` message type, so a NACK during Request/Renew/Rebind

--- a/src/dhcpv6/lease.rs
+++ b/src/dhcpv6/lease.rs
@@ -327,6 +327,19 @@ impl DhcpV6Lease {
                     .to_string(),
             ));
         }
+        // RFC 8415 section 21.22: the "prefix-length" field of an
+        // OPTION_IAPREFIX is the length of an IPv6 prefix in bits, hence
+        // cannot exceed 128.
+        if self.prefix_len > 128 {
+            return Err(DhcpError::new(
+                ErrorKind::InvalidDhcpMessage,
+                format!(
+                    "DHCPv6 lease contains invalid prefix length {}, should \
+                     be 0 - 128",
+                    self.prefix_len
+                ),
+            ));
+        }
         Ok(())
     }
 }
@@ -338,7 +351,77 @@ mod test {
     use super::*;
     use crate::{
         dhcpv6::msg::DhcpV6MessageType, DhcpV6OptionIaAddr, DhcpV6OptionIaNa,
+        DhcpV6OptionIaPd, DhcpV6OptionIaPrefix,
     };
+
+    fn prefix_delegation_reply(
+        client_duid: &DhcpV6Duid,
+        prefix_len: u8,
+    ) -> DhcpV6Message {
+        let mut msg = DhcpV6Message {
+            msg_type: DhcpV6MessageType::Reply,
+            ..Default::default()
+        };
+        msg.options
+            .insert(DhcpV6Option::ClientId(client_duid.clone()));
+        msg.options
+            .insert(DhcpV6Option::ServerId(DhcpV6Duid::Raw(vec![2])));
+        msg.options.insert(DhcpV6Option::IAPD(DhcpV6OptionIaPd::new(
+            1,
+            60,
+            90,
+            DhcpV6OptionIaPrefix::new(
+                Ipv6Addr::new(0x2001, 0x0db8, 0x000a, 0, 0, 0, 0, 0),
+                prefix_len,
+                120,
+                240,
+            ),
+        )));
+        msg
+    }
+
+    #[test]
+    fn prefix_delegation_rejects_prefix_len_over_128() {
+        let client_duid = DhcpV6Duid::Raw(vec![1]);
+        let msg = prefix_delegation_reply(&client_duid, 129);
+
+        let err = DhcpV6Lease::new_from_msg(&msg, &client_duid).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidDhcpMessage);
+        assert!(
+            err.msg().contains("prefix length"),
+            "unexpected error message: {}",
+            err.msg()
+        );
+    }
+
+    #[test]
+    fn prefix_delegation_accepts_prefix_len_128() {
+        let client_duid = DhcpV6Duid::Raw(vec![1]);
+        let msg = prefix_delegation_reply(&client_duid, 128);
+
+        let lease = DhcpV6Lease::new_from_msg(&msg, &client_duid).unwrap();
+
+        assert_eq!(lease.prefix_len, 128);
+    }
+
+    #[test]
+    fn sanitize_lease_accepts_unspecified_prefix_len_hint() {
+        let mut lease = DhcpV6Lease {
+            t1_sec: 60,
+            t2_sec: 90,
+            preferred_time_sec: 120,
+            valid_time_sec: 240,
+            address: Ipv6Addr::new(0x2001, 0x0db8, 0x000a, 0, 0, 0, 0, 0),
+            srv_duid: DhcpV6Duid::Raw(vec![2]),
+            prefix_len: 0,
+            ..Default::default()
+        };
+
+        lease.sanitize_lease().unwrap();
+
+        assert_eq!(lease.prefix_len, 0);
+    }
 
     #[test]
     fn lease_reads_ntp_fqdn_and_domain_list() {

--- a/src/integ_tests/env.rs
+++ b/src/integ_tests/env.rs
@@ -7,6 +7,7 @@ use std::{
     str::FromStr,
 };
 
+#[cfg(not(feature = "netlink"))]
 use crate::ETH_ALEN;
 
 #[cfg(feature = "netlink")]
@@ -18,6 +19,7 @@ const TEST_DHCPD_NETNS: &str = "mozim_test";
 const LOG_FILE: &str = "/tmp/mozim_test_dnsmasq_log";
 pub(crate) const TEST_NIC_CLI: &str = "dhcpcli";
 const TEST_NIC_CLI_MAC: &str = "00:23:45:67:89:1a";
+#[cfg(not(feature = "netlink"))]
 pub(crate) const TEST_NIC_CLI_MAC_RAW: [u8; ETH_ALEN] =
     [0x00, 0x23, 0x45, 0x67, 0x89, 0x1a];
 pub(crate) const TEST_PROXY_MAC1: &str = "00:11:22:33:44:55";
@@ -241,6 +243,7 @@ fn run_cmd_ignore_failure(cmd: &str) -> String {
     }
 }
 
+#[cfg(not(feature = "netlink"))]
 pub(crate) fn get_iface_index(iface_name: &str) -> u32 {
     let output = run_cmd(&format!("ip -o link show {iface_name}"));
     output
@@ -256,6 +259,7 @@ pub(crate) fn get_iface_index(iface_name: &str) -> u32 {
         })
 }
 
+#[cfg(not(feature = "netlink"))]
 pub(crate) fn get_link_local_addr(iface_name: &str) -> Ipv6Addr {
     let output =
         run_cmd(&format!("ip -6 addr show dev {iface_name} scope link"));


### PR DESCRIPTION
The `prefix-length` field of OPTION_IAPREFIX is parsed as a raw u8 and
`sanitize_lease()` never validated it, so a malicious or buggy DHCPv6
server could install a lease with an impossible IPv6 prefix, for example a
200 bits long one.

Now reject any prefix length over 128 in `sanitize_lease()` as required by
RFC 8415 section 21.22. This covers both server replies and manually
constructed leases.

Unit test cases included.